### PR TITLE
feat(RabbitMQ): LV8-Z3 Async booking-payment saga via RabbitMQ choreography

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,3 +66,10 @@ GATEWAY_INTERNAL_REVOKE_URL=http://localhost:8080/internal/revoke
 RATE_LIMIT_ENABLED=true
 RATE_LIMIT_MAX=5
 RATE_LIMIT_WINDOW=60
+
+# ── RabbitMQ (Z7 — Saga Choreography) ────────────────────────────────
+RABBITMQ_HOST=localhost
+RABBITMQ_PORT=5672
+RABBITMQ_MGMT_PORT=15672
+RABBITMQ_USER=guest
+RABBITMQ_PASS=guest

--- a/Booking Service/pom.xml
+++ b/Booking Service/pom.xml
@@ -120,6 +120,15 @@
             <version>3.0.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-amqp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.amqp</groupId>
+            <artifactId>spring-rabbit-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/Booking Service/src/main/java/ba/nwt/bookingservice/config/RabbitMQConfig.java
+++ b/Booking Service/src/main/java/ba/nwt/bookingservice/config/RabbitMQConfig.java
@@ -1,0 +1,84 @@
+package ba.nwt.bookingservice.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.amqp.core.*;
+import org.springframework.amqp.support.converter.Jackson2JavaTypeMapper;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfig {
+
+    // ── Exchange ──────────────────────────────────────────────────────────────
+    public static final String SAGA_EXCHANGE = "sportcenter.saga.exchange";
+
+    // ── Queue names ───────────────────────────────────────────────────────────
+    /** Payment Service consumes this queue */
+    public static final String BOOKING_CREATED_QUEUE   = "sportcenter.booking.created.queue";
+    /** Booking Service consumes this queue */
+    public static final String PAYMENT_COMPLETED_QUEUE = "sportcenter.payment.completed.queue";
+    /** Booking Service consumes this queue */
+    public static final String PAYMENT_FAILED_QUEUE    = "sportcenter.payment.failed.queue";
+
+    // ── Routing keys ──────────────────────────────────────────────────────────
+    public static final String BOOKING_CREATED_KEY   = "booking.saga.created";
+    public static final String PAYMENT_COMPLETED_KEY = "payment.saga.completed";
+    public static final String PAYMENT_FAILED_KEY    = "payment.saga.failed";
+
+    // ── Exchange bean ─────────────────────────────────────────────────────────
+    @Bean
+    public TopicExchange sagaExchange() {
+        return ExchangeBuilder.topicExchange(SAGA_EXCHANGE).durable(true).build();
+    }
+
+    // ── Queues declared by Booking Service (the ones it consumes) ─────────────
+    @Bean
+    public Queue paymentCompletedQueue() {
+        return QueueBuilder.durable(PAYMENT_COMPLETED_QUEUE).build();
+    }
+
+    @Bean
+    public Queue paymentFailedQueue() {
+        return QueueBuilder.durable(PAYMENT_FAILED_QUEUE).build();
+    }
+
+    // Also declare the queue that Payment Service will consume so RabbitMQ
+    // creates it before the Payment Service starts (avoids AMQP 404 errors).
+    @Bean
+    public Queue bookingCreatedQueue() {
+        return QueueBuilder.durable(BOOKING_CREATED_QUEUE).build();
+    }
+
+    // ── Bindings ──────────────────────────────────────────────────────────────
+    @Bean
+    public Binding bookingCreatedBinding() {
+        return BindingBuilder.bind(bookingCreatedQueue())
+                .to(sagaExchange()).with(BOOKING_CREATED_KEY);
+    }
+
+    @Bean
+    public Binding paymentCompletedBinding() {
+        return BindingBuilder.bind(paymentCompletedQueue())
+                .to(sagaExchange()).with(PAYMENT_COMPLETED_KEY);
+    }
+
+    @Bean
+    public Binding paymentFailedBinding() {
+        return BindingBuilder.bind(paymentFailedQueue())
+                .to(sagaExchange()).with(PAYMENT_FAILED_KEY);
+    }
+
+    // ── JSON message converter ─────────────────────────────────────────────────
+    // Inject Spring Boot's ObjectMapper (has JavaTimeModule → LocalDateTime works).
+    // INFERRED type precedence: use @RabbitListener method's parameter type for
+    // deserialization instead of the __TypeId__ header, which would contain the
+    // sender's package name (not present in this service's classpath).
+    @Bean
+    public MessageConverter jsonMessageConverter(ObjectMapper objectMapper) {
+        Jackson2JsonMessageConverter converter = new Jackson2JsonMessageConverter(objectMapper);
+        converter.setTypePrecedence(Jackson2JavaTypeMapper.TypePrecedence.INFERRED);
+        return converter;
+    }
+}

--- a/Booking Service/src/main/java/ba/nwt/bookingservice/controller/BookingSagaController.java
+++ b/Booking Service/src/main/java/ba/nwt/bookingservice/controller/BookingSagaController.java
@@ -1,0 +1,56 @@
+package ba.nwt.bookingservice.controller;
+
+import ba.nwt.bookingservice.dto.BookingRequestDTO;
+import ba.nwt.bookingservice.dto.BookingResponseDTO;
+import ba.nwt.bookingservice.service.BookingSagaService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * Exposes the asynchronous Saga-based booking creation endpoint.
+ *
+ * POST /api/bookings/saga
+ *   → Saves booking as PENDING and publishes BookingCreatedEvent to RabbitMQ.
+ *   → Returns 202 Accepted immediately; confirmation arrives asynchronously.
+ *
+ * POST /api/bookings/saga?simulateFailure=true
+ *   → Forces Payment Service to simulate a failure → tests compensating transaction.
+ */
+@RestController
+@RequestMapping("/api/bookings")
+@RequiredArgsConstructor
+@Tag(name = "Booking Saga", description = "Asynchronous booking via RabbitMQ Saga Choreography")
+public class BookingSagaController {
+
+    private final BookingSagaService bookingSagaService;
+
+    @PostMapping("/saga")
+    @Operation(
+        summary = "Z7 — Create booking via Saga Choreography (async RabbitMQ)",
+        description = """
+            Initiates the Booking-Payment Saga:
+            1. Saves Booking with status PENDING (local transaction 1).
+            2. Publishes BookingCreatedEvent to RabbitMQ exchange.
+            3. Returns 202 Accepted immediately.
+
+            Payment Service (local transaction 2) processes payment asynchronously:
+            - On success → publishes PaymentCompletedEvent → Booking becomes CONFIRMED.
+            - On failure → publishes PaymentFailedEvent → Booking becomes CANCELLED (compensating action).
+
+            Use simulateFailure=true to test the compensating transaction path.
+            """
+    )
+    public ResponseEntity<BookingResponseDTO> createViaSaga(
+            @Valid @RequestBody BookingRequestDTO dto,
+            @RequestParam(defaultValue = "CREDIT_CARD") String paymentMethod,
+            @RequestParam(defaultValue = "false") boolean simulateFailure) {
+
+        BookingResponseDTO response = bookingSagaService.initiate(dto, paymentMethod, simulateFailure);
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(response);
+    }
+}

--- a/Booking Service/src/main/java/ba/nwt/bookingservice/saga/BookingSagaConsumer.java
+++ b/Booking Service/src/main/java/ba/nwt/bookingservice/saga/BookingSagaConsumer.java
@@ -1,0 +1,41 @@
+package ba.nwt.bookingservice.saga;
+
+import ba.nwt.bookingservice.config.RabbitMQConfig;
+import ba.nwt.bookingservice.saga.event.PaymentCompletedEvent;
+import ba.nwt.bookingservice.saga.event.PaymentFailedEvent;
+import ba.nwt.bookingservice.service.BookingSagaService;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BookingSagaConsumer {
+
+    private static final Logger log = LoggerFactory.getLogger(BookingSagaConsumer.class);
+
+    private final BookingSagaService bookingSagaService;
+
+    /**
+     * Happy path: payment succeeded → confirm the booking (final state).
+     */
+    @RabbitListener(queues = RabbitMQConfig.PAYMENT_COMPLETED_QUEUE)
+    public void onPaymentCompleted(PaymentCompletedEvent event) {
+        log.info("[SAGA][{}] Received PaymentCompletedEvent for bookingId={}, paymentId={}",
+                event.getSagaId(), event.getBookingId(), event.getPaymentId());
+        bookingSagaService.confirmBooking(event);
+    }
+
+    /**
+     * Compensating transaction: payment failed → cancel the booking.
+     * This is the inverse of the initial PENDING save (local transaction 1).
+     */
+    @RabbitListener(queues = RabbitMQConfig.PAYMENT_FAILED_QUEUE)
+    public void onPaymentFailed(PaymentFailedEvent event) {
+        log.warn("[SAGA][{}] Received PaymentFailedEvent for bookingId={}, reason={}",
+                event.getSagaId(), event.getBookingId(), event.getReason());
+        bookingSagaService.cancelBooking(event);
+    }
+}

--- a/Booking Service/src/main/java/ba/nwt/bookingservice/saga/BookingSagaPublisher.java
+++ b/Booking Service/src/main/java/ba/nwt/bookingservice/saga/BookingSagaPublisher.java
@@ -1,0 +1,27 @@
+package ba.nwt.bookingservice.saga;
+
+import ba.nwt.bookingservice.config.RabbitMQConfig;
+import ba.nwt.bookingservice.saga.event.BookingCreatedEvent;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BookingSagaPublisher {
+
+    private static final Logger log = LoggerFactory.getLogger(BookingSagaPublisher.class);
+
+    private final RabbitTemplate rabbitTemplate;
+
+    public void publishBookingCreated(BookingCreatedEvent event) {
+        log.info("[SAGA][{}] Publishing BookingCreatedEvent for bookingId={}", event.getSagaId(), event.getBookingId());
+        rabbitTemplate.convertAndSend(
+                RabbitMQConfig.SAGA_EXCHANGE,
+                RabbitMQConfig.BOOKING_CREATED_KEY,
+                event
+        );
+    }
+}

--- a/Booking Service/src/main/java/ba/nwt/bookingservice/saga/event/BookingCreatedEvent.java
+++ b/Booking Service/src/main/java/ba/nwt/bookingservice/saga/event/BookingCreatedEvent.java
@@ -1,0 +1,40 @@
+package ba.nwt.bookingservice.saga.event;
+
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * Published by Booking Service when a new booking is saved with status PENDING.
+ * Consumed by Payment Service to trigger payment processing (local transaction 2).
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BookingCreatedEvent {
+
+    /** Unique identifier that links all events belonging to this saga instance. */
+    private String sagaId;
+
+    private Long bookingId;
+    private Long userId;
+    private Long facilityId;
+
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+
+    private BigDecimal totalPrice;
+
+    /** CREDIT_CARD | DEBIT_CARD | PAYPAL */
+    private String paymentMethod;
+
+    private LocalDateTime timestamp;
+
+    /**
+     * When true, Payment Service will intentionally fail the payment.
+     * Used to test the compensating transaction path without modifying business logic.
+     */
+    private boolean simulateFailure;
+}

--- a/Booking Service/src/main/java/ba/nwt/bookingservice/saga/event/PaymentCompletedEvent.java
+++ b/Booking Service/src/main/java/ba/nwt/bookingservice/saga/event/PaymentCompletedEvent.java
@@ -1,0 +1,27 @@
+package ba.nwt.bookingservice.saga.event;
+
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * Published by Payment Service when payment is successfully processed (status = PAID).
+ * Consumed by Booking Service to confirm the booking (final state).
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PaymentCompletedEvent {
+
+    private String sagaId;
+
+    private Long bookingId;
+    private Long paymentId;
+
+    private String transactionId;
+    private BigDecimal amount;
+
+    private LocalDateTime timestamp;
+}

--- a/Booking Service/src/main/java/ba/nwt/bookingservice/saga/event/PaymentFailedEvent.java
+++ b/Booking Service/src/main/java/ba/nwt/bookingservice/saga/event/PaymentFailedEvent.java
@@ -1,0 +1,26 @@
+package ba.nwt.bookingservice.saga.event;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+/**
+ * Published by Payment Service when payment processing fails.
+ * Consumed by Booking Service to execute the compensating transaction
+ * (cancel the booking — inverse of the initial PENDING save).
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PaymentFailedEvent {
+
+    private String sagaId;
+
+    private Long bookingId;
+
+    /** Human-readable reason for the failure. */
+    private String reason;
+
+    private LocalDateTime timestamp;
+}

--- a/Booking Service/src/main/java/ba/nwt/bookingservice/service/BookingSagaService.java
+++ b/Booking Service/src/main/java/ba/nwt/bookingservice/service/BookingSagaService.java
@@ -1,0 +1,128 @@
+package ba.nwt.bookingservice.service;
+
+import ba.nwt.bookingservice.dto.BookingResponseDTO;
+import ba.nwt.bookingservice.exception.ResourceNotFoundException;
+import ba.nwt.bookingservice.model.Booking;
+import ba.nwt.bookingservice.repository.BookingRepository;
+import ba.nwt.bookingservice.saga.BookingSagaPublisher;
+import ba.nwt.bookingservice.saga.event.BookingCreatedEvent;
+import ba.nwt.bookingservice.saga.event.PaymentCompletedEvent;
+import ba.nwt.bookingservice.saga.event.PaymentFailedEvent;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Orchestrates the Booking side of the Booking-Payment Saga.
+ *
+ * Saga steps owned by this service:
+ *  1. initiate()         — save Booking(PENDING)  [local transaction 1]
+ *                          → publish BookingCreatedEvent
+ *  2. confirmBooking()   — update Booking(CONFIRMED) [final state]
+ *  3. cancelBooking()    — update Booking(CANCELLED)  [compensating / inverse action]
+ */
+@Service
+@RequiredArgsConstructor
+public class BookingSagaService {
+
+    private static final Logger log = LoggerFactory.getLogger(BookingSagaService.class);
+
+    private final BookingRepository bookingRepository;
+    private final BookingSagaPublisher publisher;
+    private final ModelMapper modelMapper;
+
+    /**
+     * Local transaction 1: persist booking as PENDING, then publish the event.
+     * The HTTP response returns immediately (202 Accepted) — confirmation arrives later via RabbitMQ.
+     */
+    @Transactional
+    public BookingResponseDTO initiate(ba.nwt.bookingservice.dto.BookingRequestDTO dto,
+                                       String paymentMethod,
+                                       boolean simulateFailure) {
+        if (dto.getEndTime().isBefore(dto.getStartTime())) {
+            throw new IllegalArgumentException("End time must be after start time");
+        }
+
+        String sagaId = UUID.randomUUID().toString();
+
+        // ── Local Transaction 1: save booking PENDING ──────────────────────────
+        Booking booking = bookingRepository.save(Booking.builder()
+                .userId(dto.getUserId())
+                .facilityId(dto.getFacilityId())
+                .startTime(dto.getStartTime())
+                .endTime(dto.getEndTime())
+                .totalPrice(dto.getTotalPrice())
+                .isRecurring(dto.getIsRecurring() != null ? dto.getIsRecurring() : false)
+                .recurringPattern(dto.getRecurringPattern())
+                .status(Booking.BookingStatus.PENDING)
+                .build());
+
+        log.info("[SAGA][{}] Local txn 1 complete — Booking saved id={} status=PENDING", sagaId, booking.getId());
+
+        // ── Publish event to RabbitMQ (triggers Payment Service) ──────────────
+        publisher.publishBookingCreated(BookingCreatedEvent.builder()
+                .sagaId(sagaId)
+                .bookingId(booking.getId())
+                .userId(booking.getUserId())
+                .facilityId(booking.getFacilityId())
+                .startTime(booking.getStartTime())
+                .endTime(booking.getEndTime())
+                .totalPrice(booking.getTotalPrice())
+                .paymentMethod(paymentMethod == null ? "CREDIT_CARD" : paymentMethod)
+                .simulateFailure(simulateFailure)
+                .timestamp(LocalDateTime.now())
+                .build());
+
+        return modelMapper.map(booking, BookingResponseDTO.class);
+    }
+
+    /**
+     * Triggered by PaymentCompletedEvent — marks booking as CONFIRMED (final state).
+     * Both local transactions have succeeded; the saga is complete.
+     */
+    @Transactional
+    public void confirmBooking(PaymentCompletedEvent event) {
+        Booking booking = bookingRepository.findById(event.getBookingId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Booking not found id=" + event.getBookingId()));
+
+        if (booking.getStatus() != Booking.BookingStatus.PENDING) {
+            log.warn("[SAGA][{}] confirmBooking skipped — booking {} already in status {}",
+                    event.getSagaId(), event.getBookingId(), booking.getStatus());
+            return;
+        }
+
+        booking.setStatus(Booking.BookingStatus.CONFIRMED);
+        bookingRepository.save(booking);
+        log.info("[SAGA][{}] Booking id={} CONFIRMED — saga COMPLETE (paymentId={}, txn={})",
+                event.getSagaId(), event.getBookingId(), event.getPaymentId(), event.getTransactionId());
+    }
+
+    /**
+     * Triggered by PaymentFailedEvent — compensating (inverse) action.
+     * Cancels the booking that was created in local transaction 1.
+     */
+    @Transactional
+    public void cancelBooking(PaymentFailedEvent event) {
+        Booking booking = bookingRepository.findById(event.getBookingId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Booking not found id=" + event.getBookingId()));
+
+        if (booking.getStatus() != Booking.BookingStatus.PENDING) {
+            log.warn("[SAGA][{}] cancelBooking skipped — booking {} already in status {}",
+                    event.getSagaId(), event.getBookingId(), booking.getStatus());
+            return;
+        }
+
+        booking.setStatus(Booking.BookingStatus.CANCELLED);
+        bookingRepository.save(booking);
+        log.warn("[SAGA][{}] Booking id={} CANCELLED (compensating txn) — reason: {}",
+                event.getSagaId(), event.getBookingId(), event.getReason());
+    }
+}

--- a/Booking Service/src/main/resources/application.properties
+++ b/Booking Service/src/main/resources/application.properties
@@ -26,3 +26,9 @@ management.endpoint.health.show-details=always
 
 springdoc.api-docs.path=/api-docs
 springdoc.swagger-ui.path=/swagger-ui.html
+
+spring.rabbitmq.host=${RABBITMQ_HOST:localhost}
+spring.rabbitmq.port=${RABBITMQ_PORT:5672}
+spring.rabbitmq.username=${RABBITMQ_USER:guest}
+spring.rabbitmq.password=${RABBITMQ_PASS:guest}
+spring.rabbitmq.virtual-host=/

--- a/Booking Service/src/test/java/ba/nwt/bookingservice/BookingServiceApplicationTests.java
+++ b/Booking Service/src/test/java/ba/nwt/bookingservice/BookingServiceApplicationTests.java
@@ -8,6 +8,10 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 class BookingServiceApplicationTests {
 
+    /** Mock RabbitTemplate so the context loads without a real RabbitMQ broker. */
+    @org.springframework.boot.test.mock.mockito.MockBean
+    private org.springframework.amqp.rabbit.core.RabbitTemplate rabbitTemplate;
+
     @Test
     void contextLoads() {
     }

--- a/Booking Service/src/test/java/ba/nwt/bookingservice/saga/BookingSagaServiceTest.java
+++ b/Booking Service/src/test/java/ba/nwt/bookingservice/saga/BookingSagaServiceTest.java
@@ -1,0 +1,238 @@
+package ba.nwt.bookingservice.saga;
+
+import ba.nwt.bookingservice.dto.BookingRequestDTO;
+import ba.nwt.bookingservice.dto.BookingResponseDTO;
+import ba.nwt.bookingservice.exception.ResourceNotFoundException;
+import ba.nwt.bookingservice.model.Booking;
+import ba.nwt.bookingservice.repository.BookingRepository;
+import ba.nwt.bookingservice.saga.event.PaymentCompletedEvent;
+import ba.nwt.bookingservice.saga.event.PaymentFailedEvent;
+import ba.nwt.bookingservice.service.BookingSagaService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.modelmapper.ModelMapper;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for BookingSagaService — the Booking Service's side of the Saga.
+ *
+ * Tests cover:
+ *  1. initiate()      — local transaction 1 (PENDING save) + event publishing
+ *  2. confirmBooking() — happy path final state (CONFIRMED)
+ *  3. cancelBooking()  — compensating transaction (CANCELLED)
+ *  4. Idempotency checks (skip if already in terminal state)
+ */
+@ExtendWith(MockitoExtension.class)
+class BookingSagaServiceTest {
+
+    @Mock
+    private BookingRepository bookingRepository;
+
+    @Mock
+    private BookingSagaPublisher publisher;
+
+    @Mock
+    private ModelMapper modelMapper;
+
+    @InjectMocks
+    private BookingSagaService bookingSagaService;
+
+    private BookingRequestDTO validRequest;
+
+    @BeforeEach
+    void setUp() {
+        validRequest = BookingRequestDTO.builder()
+                .userId(1L)
+                .facilityId(2L)
+                .startTime(LocalDateTime.now().plusDays(1))
+                .endTime(LocalDateTime.now().plusDays(1).plusHours(2))
+                .totalPrice(new BigDecimal("150.00"))
+                .isRecurring(false)
+                .build();
+    }
+
+    // ── initiate() ────────────────────────────────────────────────────────────
+
+    @Test
+    void initiate_savesBookingAsPending_andPublishesEvent() {
+        Booking saved = Booking.builder()
+                .id(10L)
+                .userId(1L)
+                .facilityId(2L)
+                .startTime(validRequest.getStartTime())
+                .endTime(validRequest.getEndTime())
+                .totalPrice(new BigDecimal("150.00"))
+                .status(Booking.BookingStatus.PENDING)
+                .build();
+
+        when(bookingRepository.save(any(Booking.class))).thenReturn(saved);
+        when(modelMapper.map(saved, BookingResponseDTO.class))
+                .thenReturn(BookingResponseDTO.builder().id(10L)
+                        .status(Booking.BookingStatus.PENDING).build());
+
+        BookingResponseDTO result = bookingSagaService.initiate(validRequest, "CREDIT_CARD", false);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getStatus()).isEqualTo(Booking.BookingStatus.PENDING);
+
+        // Verify booking saved with PENDING status
+        ArgumentCaptor<Booking> bookingCaptor = ArgumentCaptor.forClass(Booking.class);
+        verify(bookingRepository).save(bookingCaptor.capture());
+        assertThat(bookingCaptor.getValue().getStatus()).isEqualTo(Booking.BookingStatus.PENDING);
+
+        // Verify BookingCreatedEvent was published
+        verify(publisher).publishBookingCreated(argThat(event ->
+                event.getBookingId().equals(10L)
+                && event.getSagaId() != null
+                && !event.isSimulateFailure()
+        ));
+    }
+
+    @Test
+    void initiate_withSimulateFailure_publishesEventWithSimulateFlagTrue() {
+        Booking saved = Booking.builder().id(11L).status(Booking.BookingStatus.PENDING).build();
+        when(bookingRepository.save(any())).thenReturn(saved);
+        when(modelMapper.map(any(), eq(BookingResponseDTO.class)))
+                .thenReturn(BookingResponseDTO.builder().id(11L).build());
+
+        bookingSagaService.initiate(validRequest, "PAYPAL", true);
+
+        verify(publisher).publishBookingCreated(argThat(event -> event.isSimulateFailure()));
+    }
+
+    @Test
+    void initiate_throwsIllegalArgument_whenEndTimeBeforeStartTime() {
+        validRequest.setEndTime(validRequest.getStartTime().minusHours(1));
+
+        assertThatThrownBy(() -> bookingSagaService.initiate(validRequest, "CREDIT_CARD", false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("End time must be after start time");
+
+        verifyNoInteractions(publisher);
+    }
+
+    // ── confirmBooking() ──────────────────────────────────────────────────────
+
+    @Test
+    void confirmBooking_updatesStatusToConfirmed() {
+        Booking booking = Booking.builder()
+                .id(10L).status(Booking.BookingStatus.PENDING).build();
+
+        when(bookingRepository.findById(10L)).thenReturn(Optional.of(booking));
+        when(bookingRepository.save(any())).thenReturn(booking);
+
+        PaymentCompletedEvent event = PaymentCompletedEvent.builder()
+                .sagaId("saga-001")
+                .bookingId(10L)
+                .paymentId(99L)
+                .transactionId("TXN-TEST")
+                .amount(new BigDecimal("150.00"))
+                .timestamp(LocalDateTime.now())
+                .build();
+
+        bookingSagaService.confirmBooking(event);
+
+        ArgumentCaptor<Booking> captor = ArgumentCaptor.forClass(Booking.class);
+        verify(bookingRepository).save(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(Booking.BookingStatus.CONFIRMED);
+    }
+
+    @Test
+    void confirmBooking_isIdempotent_whenAlreadyConfirmed() {
+        Booking booking = Booking.builder()
+                .id(10L).status(Booking.BookingStatus.CONFIRMED).build();
+
+        when(bookingRepository.findById(10L)).thenReturn(Optional.of(booking));
+
+        PaymentCompletedEvent event = PaymentCompletedEvent.builder()
+                .sagaId("saga-dup")
+                .bookingId(10L)
+                .build();
+
+        bookingSagaService.confirmBooking(event);
+
+        // Should not save again when already in terminal state
+        verify(bookingRepository, never()).save(any());
+    }
+
+    @Test
+    void confirmBooking_throwsResourceNotFoundException_whenBookingMissing() {
+        when(bookingRepository.findById(99L)).thenReturn(Optional.empty());
+
+        PaymentCompletedEvent event = PaymentCompletedEvent.builder()
+                .sagaId("saga-x")
+                .bookingId(99L)
+                .build();
+
+        assertThatThrownBy(() -> bookingSagaService.confirmBooking(event))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    // ── cancelBooking() (compensating transaction) ────────────────────────────
+
+    @Test
+    void cancelBooking_compensatingTransaction_updatesStatusToCancelled() {
+        Booking booking = Booking.builder()
+                .id(10L).status(Booking.BookingStatus.PENDING).build();
+
+        when(bookingRepository.findById(10L)).thenReturn(Optional.of(booking));
+        when(bookingRepository.save(any())).thenReturn(booking);
+
+        PaymentFailedEvent event = PaymentFailedEvent.builder()
+                .sagaId("saga-002")
+                .bookingId(10L)
+                .reason("Card declined")
+                .timestamp(LocalDateTime.now())
+                .build();
+
+        bookingSagaService.cancelBooking(event);
+
+        ArgumentCaptor<Booking> captor = ArgumentCaptor.forClass(Booking.class);
+        verify(bookingRepository).save(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(Booking.BookingStatus.CANCELLED);
+    }
+
+    @Test
+    void cancelBooking_isIdempotent_whenAlreadyCancelled() {
+        Booking booking = Booking.builder()
+                .id(10L).status(Booking.BookingStatus.CANCELLED).build();
+
+        when(bookingRepository.findById(10L)).thenReturn(Optional.of(booking));
+
+        PaymentFailedEvent event = PaymentFailedEvent.builder()
+                .sagaId("saga-dup")
+                .bookingId(10L)
+                .reason("Already cancelled")
+                .build();
+
+        bookingSagaService.cancelBooking(event);
+
+        verify(bookingRepository, never()).save(any());
+    }
+
+    @Test
+    void cancelBooking_throwsResourceNotFoundException_whenBookingMissing() {
+        when(bookingRepository.findById(999L)).thenReturn(Optional.empty());
+
+        PaymentFailedEvent event = PaymentFailedEvent.builder()
+                .sagaId("saga-y")
+                .bookingId(999L)
+                .reason("Test")
+                .build();
+
+        assertThatThrownBy(() -> bookingSagaService.cancelBooking(event))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+}

--- a/Booking Service/src/test/resources/application-test.properties
+++ b/Booking Service/src/test/resources/application-test.properties
@@ -18,3 +18,6 @@ spring.cloud.openfeign.circuitbreaker.enabled=false
 spring.cloud.discovery.enabled=false
 eureka.client.enabled=false
 
+# ── Z8 — Disable RabbitMQ auto-connect in unit/slice tests ───────────────────
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration
+

--- a/IZVJESTAJ_LV8.md
+++ b/IZVJESTAJ_LV8.md
@@ -1,0 +1,496 @@
+# Zadatak 7 — Asinkrona komunikacija s RabbitMQ (Saga Choreography)
+
+## Sadržaj
+1. [Pregled arhitekture](#1-pregled-arhitekture)
+2. [Šta je Saga Choreography?](#2-šta-je-saga-choreography)
+3. [Dizajn rješenja](#3-dizajn-rješenja)
+4. [Dijagram toka](#4-dijagram-toka)
+5. [RabbitMQ Exchange/Queue dizajn](#5-rabbitmq-exchangequeue-dizajn)
+6. [Implementirani fajlovi](#6-implementirani-fajlovi)
+7. [Detaljan opis svake klase](#7-detaljan-opis-svake-klase)
+8. [Lokalne transakcije i njihova međuzavisnost](#8-lokalne-transakcije-i-njihova-međuzavisnost)
+9. [Kompenzacijske transakcije (Inverse Actions)](#9-kompenzacijske-transakcije-inverse-actions)
+10. [Pokretanje i testiranje](#10-pokretanje-i-testiranje)
+11. [Primjer HTTP poziva](#11-primjer-http-poziva)
+
+---
+
+## 1. Pregled arhitekture
+
+Implementirana je asinkrona saga između dva mikroservisa:
+
+| Mikroservis | Port | Uloga u sagi |
+|---|---|---|
+| **Booking Service** | 8083 | Lokalna transakcija 1: kreira rezervaciju |
+| **Payment Service** | 8084 | Lokalna transakcija 2: procesira plaćanje |
+| **RabbitMQ** | 5672 (AMQP), 15672 (Management UI) | Message broker |
+
+---
+
+## 2. Šta je Saga Choreography?
+
+**Saga** je pattern za upravljanje distribuiranim transakcijama u mikroservisima, gdje se umjesto jedne globalne transakcije koriste lokalne transakcije po servisu, a greška se ispravlja **kompenzacijskim transakcijama**.
+
+**Choreography** znači da ne postoji centralni orkestrator — svaki servis sluša događaje i sam donosi odluku o sljedećem koraku. Servisi komuniciraju putem poruka (ovdje RabbitMQ).
+
+**Za razliku od synchronous pristupa (Z5):**
+- Klijent ne čeka dok se sve transakcije ne završe
+- Servis odmah vraća `202 Accepted`
+- Završetak stiže asinkrono
+
+---
+
+## 3. Dizajn rješenja
+
+### Odabrana funkcionalnost: Kreiranje rezervacije + plaćanja
+
+Ova funkcionalnost je idealna za sagu jer:
+- Booking Service i Payment Service su potpuno nezavisni mikroservisi s odvojenim bazama
+- Kreiranje rezervacije bez plaćanja nema smisla — **obje transakcije moraju proći ili obje pasti**
+- Ako plaćanje ne prođe, rezervacija se mora poništiti (kompenzacijska akcija)
+
+### Stanja kroz sagu
+
+```
+Booking: PENDING → CONFIRMED  (sretni put)
+Booking: PENDING → CANCELLED  (kompenzacija ako plaćanje ne prođe)
+
+Payment: PENDING → PAID       (sretni put)
+Payment: PENDING → FAILED     (neuspjelo plaćanje)
+```
+
+---
+
+## 4. Dijagram toka
+
+### 4.1 Sretni put (Happy Path)
+
+```
+Klijent          Booking Service         RabbitMQ              Payment Service
+   |                    |                    |                        |
+   |-- POST /saga ----→ |                    |                        |
+   |                    |                    |                        |
+   |          [Lokalna transakcija 1]        |                        |
+   |          Booking → PENDING             |                        |
+   |          (upisano u booking_db)        |                        |
+   |                    |                    |                        |
+   |                    |-- BookingCreatedEvent ─────────────────────→|
+   |                    |                    |                        |
+   |←-- 202 Accepted -- |                    |          [Lokalna transakcija 2]
+   |                    |                    |          Payment → PENDING
+   |                    |                    |          Payment → PAID
+   |                    |                    |          (upisano u payment_db)
+   |                    |                    |                        |
+   |                    |←── PaymentCompletedEvent ──────────────────|
+   |                    |                    |                        |
+   |          Booking → CONFIRMED           |                        |
+   |          (FINALNO STANJE)              |                        |
+```
+
+### 4.2 Kompenzacijski put (Compensating Transactions)
+
+```
+Klijent          Booking Service         RabbitMQ              Payment Service
+   |                    |                    |                        |
+   |-- POST /saga ----→ |                    |                        |
+   |                    |                    |                        |
+   |          [Lokalna transakcija 1]        |                        |
+   |          Booking → PENDING             |                        |
+   |                    |                    |                        |
+   |                    |-- BookingCreatedEvent ─────────────────────→|
+   |                    |                    |                        |
+   |←-- 202 Accepted -- |                    |          [Lokalna transakcija 2]
+   |                    |                    |          Payment → PENDING
+   |                    |                    |          Payment → FAILED ← greška!
+   |                    |                    |                        |
+   |                    |←── PaymentFailedEvent ─────────────────────|
+   |                    |                    |                        |
+   |          [KOMPENZACIJSKA TRANSAKCIJA]  |                        |
+   |          Booking → CANCELLED           |                        |
+   |          (inverzna akcija)             |                        |
+```
+
+### 4.3 Sekvencijalni dijagram (ASCII)
+
+```
+┌─────────────┐     ┌────────────────┐     ┌──────────────┐     ┌─────────────────┐
+│   Klijent   │     │ Booking Service │     │   RabbitMQ   │     │ Payment Service │
+└──────┬──────┘     └───────┬────────┘     └──────┬───────┘     └────────┬────────┘
+       │                    │                      │                      │
+       │  POST /api/bookings/saga                  │                      │
+       │───────────────────→│                      │                      │
+       │                    │                      │                      │
+       │         ┌──────────┴──────────┐           │                      │
+       │         │ Lokalna TX 1        │           │                      │
+       │         │ Booking → PENDING   │           │                      │
+       │         │ (booking_db)        │           │                      │
+       │         └──────────┬──────────┘           │                      │
+       │                    │                      │                      │
+       │                    │  BookingCreatedEvent  │                      │
+       │                    │─────────────────────→│                      │
+       │                    │                      │  BookingCreatedEvent  │
+       │  202 Accepted       │                      │─────────────────────→│
+       │←───────────────────│                      │                      │
+       │                    │                      │    ┌──────────────────┴──────────┐
+       │                    │                      │    │ Lokalna TX 2               │
+       │                    │                      │    │ Payment → PENDING → PAID    │
+       │                    │                      │    │   ili → FAILED              │
+       │                    │                      │    └──────────────────┬──────────┘
+       │                    │                      │                      │
+       │                    │  [SRETNI PUT]         │                      │
+       │                    │  PaymentCompletedEvent│                      │
+       │                    │←─────────────────────│←─────────────────────│
+       │         ┌──────────┴──────────┐           │                      │
+       │         │ Booking → CONFIRMED │           │                      │
+       │         │ (FINALNO STANJE)    │           │                      │
+       │         └─────────────────────┘           │                      │
+       │                    │                      │                      │
+       │                    │  [KOMPENZACIJA]       │                      │
+       │                    │  PaymentFailedEvent   │                      │
+       │                    │←─────────────────────│←─────────────────────│
+       │         ┌──────────┴──────────┐           │                      │
+       │         │ Booking → CANCELLED │           │                      │
+       │         │ (INVERZNA AKCIJA)   │           │                      │
+       │         └─────────────────────┘           │                      │
+```
+
+---
+
+## 5. RabbitMQ Exchange/Queue dizajn
+
+```
+                    sportcenter.saga.exchange
+                    (Topic Exchange, durable)
+                            │
+           ┌────────────────┼────────────────────┐
+           │                │                    │
+   booking.saga.created  payment.saga.completed  payment.saga.failed
+           │                │                    │
+           ▼                ▼                    ▼
+  sportcenter.booking  sportcenter.payment  sportcenter.payment
+  .created.queue       .completed.queue     .failed.queue
+  (Payment Service     (Booking Service     (Booking Service
+   konzumira)           konzumira)           konzumira)
+```
+
+| Element | Vrijednost |
+|---|---|
+| Exchange | `sportcenter.saga.exchange` (Topic, durable) |
+| Queue 1 | `sportcenter.booking.created.queue` (durable) |
+| Queue 2 | `sportcenter.payment.completed.queue` (durable) |
+| Queue 3 | `sportcenter.payment.failed.queue` (durable) |
+| Routing key 1 | `booking.saga.created` |
+| Routing key 2 | `payment.saga.completed` |
+| Routing key 3 | `payment.saga.failed` |
+| Serialization | JSON (Jackson2JsonMessageConverter) |
+
+**Zašto Topic Exchange?**
+Topic exchange dozvoljava fleksibilno rutiranje po wildcardima (npr. `booking.saga.*`). Ako se u budućnosti doda novi tip saga eventa, nema potrebe mijenjati exchange.
+
+---
+
+## 6. Implementirani fajlovi
+
+### Booking Service (novi fajlovi)
+
+```
+src/main/java/ba/nwt/bookingservice/
+├── config/
+│   └── RabbitMQConfig.java            ← Exchange, queues, bindings, JSON converter
+├── saga/
+│   ├── event/
+│   │   ├── BookingCreatedEvent.java   ← Event koji se šalje Payment Serviceu
+│   │   ├── PaymentCompletedEvent.java ← Event koji se prima (sretni put)
+│   │   └── PaymentFailedEvent.java    ← Event koji se prima (kompenzacija)
+│   ├── BookingSagaPublisher.java      ← Šalje BookingCreatedEvent na RabbitMQ
+│   └── BookingSagaConsumer.java       ← Sluša PaymentCompleted/Failed evente
+├── service/
+│   └── BookingSagaService.java        ← Lokalna txn 1, confirm, cancel
+└── controller/
+    └── BookingSagaController.java     ← POST /api/bookings/saga
+```
+
+### Payment Service (novi fajlovi)
+
+```
+src/main/java/ba/nwt/paymentservice/
+├── config/
+│   └── RabbitMQConfig.java              ← Exchange, queues, bindings, JSON converter
+├── saga/
+│   ├── event/
+│   │   ├── BookingCreatedEvent.java     ← Event koji se prima od Booking Servicea
+│   │   ├── PaymentCompletedEvent.java   ← Event koji se šalje (sretni put)
+│   │   └── PaymentFailedEvent.java      ← Event koji se šalje (kompenzacija)
+│   ├── PaymentSagaPublisher.java        ← Šalje Completed/Failed evente
+│   └── PaymentSagaConsumer.java         ← Sluša BookingCreated event
+└── service/
+    └── PaymentSagaService.java          ← Lokalna txn 2, proces + kompenzacija
+```
+
+### Izmijenjeni fajlovi
+
+| Fajl | Izmjena |
+|---|---|
+| `Booking Service/pom.xml` | Dodana spring-boot-starter-amqp zavisnost |
+| `Payment Service/pom.xml` | Dodana spring-boot-starter-amqp zavisnost |
+| `Booking Service/application.properties` | Dodana RabbitMQ konfiguracija |
+| `Payment Service/application.properties` | Dodana RabbitMQ konfiguracija |
+| `Booking Service/application-test.properties` | Isključen RabbitMQ u testovima |
+| `Payment Service/application-test.properties` | Isključen RabbitMQ u testovima |
+| `docker-compose.yml` | Dodan RabbitMQ 3.13-management container |
+| `.env.example` | Dodane RabbitMQ env varijable |
+
+### Test fajlovi
+
+```
+Booking Service:
+└── src/test/java/ba/nwt/bookingservice/saga/BookingSagaServiceTest.java (9 testova)
+
+Payment Service:
+└── src/test/java/ba/nwt/paymentservice/saga/PaymentSagaServiceTest.java (6 testova)
+```
+
+---
+
+## 7. Detaljan opis svake klase
+
+### `BookingSagaService.java`
+
+Centralna klasa Booking Servicea za sagu. Ima 3 metode:
+
+**`initiate(dto, paymentMethod, simulateFailure)`**
+- Validacija: endTime mora biti nakon startTime
+- Generiše `sagaId` (UUID) koji prati sve događaje te instance sage
+- **Lokalna transakcija 1**: sprema `Booking` sa statusom `PENDING` u booking_db
+- Šalje `BookingCreatedEvent` na RabbitMQ
+- Vraća odmah (asinkrono) — HTTP klijent dobija 202
+
+**`confirmBooking(event)`**
+- Prima `PaymentCompletedEvent`
+- Mijenja status bookinga iz `PENDING` → `CONFIRMED`
+- Ovo je **finalno stanje** — saga je uspješno završena
+- Idempotentno: ignoriše ako booking već nije PENDING
+
+**`cancelBooking(event)`**
+- Prima `PaymentFailedEvent`
+- **Kompenzacijska (inverzna) akcija**: mijenja `PENDING` → `CANCELLED`
+- Poništava efekat lokalne transakcije 1
+- Idempotentno: ignoriše ako booking već nije PENDING
+
+### `PaymentSagaService.java`
+
+Centralna klasa Payment Servicea. Ima 1 metodu:
+
+**`processPayment(event)`**
+- **Lokalna transakcija 2**: sprema `Payment` sa statusom `PENDING`
+- Generiše `transactionId` formata `TXN-SAGA-XXXXXXXX`
+- Ako `simulateFailure=true`: mijenja u `FAILED`, šalje `PaymentFailedEvent`
+- Happy path: mijenja u `PAID`, šalje `PaymentCompletedEvent`
+- Exception handling: ako dođe do neočekivane greške → `FAILED` + `PaymentFailedEvent`
+
+### `BookingSagaConsumer.java`
+
+RabbitMQ listener u Booking Serviceu:
+- `@RabbitListener(queues = PAYMENT_COMPLETED_QUEUE)` → poziva `confirmBooking()`
+- `@RabbitListener(queues = PAYMENT_FAILED_QUEUE)` → poziva `cancelBooking()`
+
+### `PaymentSagaConsumer.java`
+
+RabbitMQ listener u Payment Serviceu:
+- `@RabbitListener(queues = BOOKING_CREATED_QUEUE)` → poziva `processPayment()`
+
+### `BookingSagaPublisher.java` / `PaymentSagaPublisher.java`
+
+Šalju poruke na RabbitMQ koristeći `RabbitTemplate.convertAndSend()` sa exchange + routing key.
+
+### `BookingSagaController.java`
+
+- `POST /api/bookings/saga` — poziva `initiate()`, vraća 202 Accepted
+- Query param `simulateFailure=true` testira kompenzacijski put
+
+---
+
+## 8. Lokalne transakcije i njihova međuzavisnost
+
+### Lokalna transakcija 1 (Booking Service)
+**Gdje**: `BookingSagaService.initiate()`  
+**Šta radi**: Sprema `Booking` entitet sa statusom `PENDING` u `sportcenter_booking_db.booking`  
+**Kada se poziva**: Odmah pri HTTP requestu  
+**Na grešku**: Rollback kroz `@Transactional` — booking se ne spremi uopće
+
+### Lokalna transakcija 2 (Payment Service)
+**Gdje**: `PaymentSagaService.processPayment()`  
+**Šta radi**: Sprema `Payment` entitet u `sportcenter_payment_db.payment`  
+**Kada se poziva**: Asinkrono, kada RabbitMQ dostavi `BookingCreatedEvent`  
+**Na grešku**: Payment se označi kao `FAILED`, šalje se `PaymentFailedEvent`
+
+### Međuzavisnost
+
+```
+     TX1 (Booking = PENDING)  ←──────── TX2 mora proći
+              │                              │
+              │   ako TX2 PROĐE:             │
+              └──→ Booking = CONFIRMED   ←───┘ (finalno stanje)
+              │
+              │   ako TX2 PADNE:
+              └──→ Booking = CANCELLED        (kompenzacija TX1)
+```
+
+**Obje transakcije su međusobno ovisne**:
+- TX2 ovisi o TX1 jer uzima `bookingId` iz `BookingCreatedEvent`
+- TX1 ovisi o TX2 jer njen konačni status ovisi o ishodu TX2
+- Ako TX2 padne → TX1 se kompenzira (inverzna akcija)
+- Ako TX1 padne → TX2 se nikad ni ne pokreće (event se ne šalje)
+
+---
+
+## 9. Kompenzacijske transakcije (Inverse Actions)
+
+| Akcija | Kompenzacijska (inverzna) akcija |
+|---|---|
+| Booking sprema se kao `PENDING` (TX1) | Booking se mijenja u `CANCELLED` (TX1 kompenzacija) |
+| Payment se kreira i mijenja u `PAID` (TX2) | Payment ostaje `FAILED` (nema dalje upisivanja, TX2 kompenzira sama sebe) |
+
+**Napomena**: Kompenzacijska akcija u TX1 je eksplicitna promjena stanja (`CANCELLED`), a ne brisanje. Ovo je namjerno — audit trail zahtijeva da se zna zašto je booking otkazan.
+
+### Idempotentnost
+
+Obje kompenzacijske metode su **idempotentne** — provjeravaju da li je booking već u terminalnom stanju (CONFIRMED/CANCELLED) prije nego što rade ikakve izmjene. Ovo štiti od dupliranih poruka ("at-least-once delivery" garancija RabbitMQ-a).
+
+---
+
+## 10. Pokretanje i testiranje
+
+### Pokretanje RabbitMQ putem Dockera
+
+```bash
+docker-compose up rabbitmq
+```
+
+RabbitMQ Management UI dostupan na: http://localhost:15672  
+Kredencijali: `guest` / `guest`
+
+### Pokretanje servisa
+
+```bash
+# Pokrenuti servise redom:
+# 1. Discovery Server (8761)
+# 2. Config Server (8888)
+# 3. Booking Service (8083)
+# 4. Payment Service (8084)
+```
+
+### Pokretanje testova
+
+```bash
+# Booking Service testovi
+cd "Booking Service"
+mvn test -Dspring.profiles.active=test
+
+# Payment Service testovi
+cd "Payment Service"
+mvn test -Dspring.profiles.active=test
+```
+
+### Pregled queues u Management UI
+
+1. Otvoriti http://localhost:15672
+2. Ući na tab **Queues**
+3. Vidjeti sve 3 queues: `booking.created`, `payment.completed`, `payment.failed`
+
+---
+
+## 11. Primjer HTTP poziva
+
+### Sretni put — kreiranje rezervacije putem sage
+
+```bash
+POST http://localhost:8083/api/bookings/saga?paymentMethod=CREDIT_CARD
+
+{
+  "userId": 1,
+  "facilityId": 1,
+  "startTime": "2026-06-01T10:00:00",
+  "endTime": "2026-06-01T12:00:00",
+  "totalPrice": 150.00
+}
+```
+
+**Odgovor (202 Accepted):**
+```json
+{
+  "id": 42,
+  "userId": 1,
+  "facilityId": 1,
+  "startTime": "2026-06-01T10:00:00",
+  "endTime": "2026-06-01T12:00:00",
+  "totalPrice": 150.00,
+  "status": "PENDING",
+  "createdAt": "2026-05-12T21:00:00"
+}
+```
+
+→ Status je `PENDING` odmah  
+→ Nakon kratkog vremena, u bazi: `status = CONFIRMED`
+
+### Testiranje kompenzacijske transakcije
+
+```bash
+POST http://localhost:8083/api/bookings/saga?paymentMethod=CREDIT_CARD&simulateFailure=true
+
+{
+  "userId": 1,
+  "facilityId": 1,
+  "startTime": "2026-06-02T10:00:00",
+  "endTime": "2026-06-02T12:00:00",
+  "totalPrice": 150.00
+}
+```
+
+**Tok:**
+1. Booking se sprema kao `PENDING`
+2. `BookingCreatedEvent` ide na RabbitMQ (sa `simulateFailure=true`)
+3. Payment Service kreira payment, ali ga odmah označi kao `FAILED`
+4. Šalje `PaymentFailedEvent`
+5. Booking Service prima event → Booking postaje `CANCELLED`
+
+**Provjera u bazi:**
+```sql
+-- Booking Service DB
+SELECT id, status FROM booking WHERE id = 42;
+-- Rezultat: status = 'CANCELLED'
+
+-- Payment Service DB
+SELECT id, status, transaction_id FROM payment WHERE booking_id = 42;
+-- Rezultat: status = 'FAILED'
+```
+
+### Provjera logova
+
+Pratiti logove traženjem `[SAGA]` prefiksa:
+
+```
+[SAGA][a3f7b2c1-...] Local txn 1 complete — Booking saved id=42 status=PENDING
+[SAGA][a3f7b2c1-...] Publishing BookingCreatedEvent for bookingId=42
+[SAGA][a3f7b2c1-...] Received BookingCreatedEvent for bookingId=42 amount=150.00
+[SAGA][a3f7b2c1-...] Local txn 2 start — processing payment for bookingId=42
+[SAGA][a3f7b2c1-...] Payment saved id=99 status=PENDING transactionId=TXN-SAGA-ABC123
+[SAGA][a3f7b2c1-...] Payment id=99 PAID — publishing PaymentCompletedEvent
+[SAGA][a3f7b2c1-...] Received PaymentCompletedEvent for bookingId=42 paymentId=99
+[SAGA][a3f7b2c1-...] Booking id=42 CONFIRMED — saga COMPLETE (paymentId=99, txn=TXN-SAGA-ABC123)
+```
+
+---
+
+## Sažetak
+
+| Zahtjev zadatka | Implementirano |
+|---|---|
+| Asinkrona komunikacija putem RabbitMQ | ✅ Topic Exchange + 3 queues |
+| Bar 2 upisa u različitim mikroservisima | ✅ TX1: booking_db, TX2: payment_db |
+| Obje transakcije međusobno ovisne | ✅ TX2 triggerovana eventom TX1; ishod TX2 mijenja TX1 |
+| Kompenzacijska (inverzna) akcija | ✅ Booking → CANCELLED kada Payment → FAILED |
+| Finalno označavanje uspješne sage | ✅ Booking → CONFIRMED kada Payment → PAID |
+| Event-based / Saga Choreography | ✅ Nema centralnog orkestratora |
+| Dijagram komunikacije | ✅ ASCII dijagrami u ovom dokumentu |
+| Testovi | ✅ 15 unit testova (BookingSagaServiceTest + PaymentSagaServiceTest) |

--- a/IZVJESTAJ_LV8_DETALJAN.md
+++ b/IZVJESTAJ_LV8_DETALJAN.md
@@ -1,0 +1,1296 @@
+# Zadatak 3 (Z7) — Asinkrona komunikacija s RabbitMQ: Saga Choreography
+## Detaljan izvještaj za odbranu
+
+> **Autor:** SportsCenterSystem tim  
+> **Zadatak:** Implementirati asinhronu komunikaciju koristeći RabbitMQ, event-based pristup, Saga Choreography pattern sa kompenzacijskim transakcijama.
+
+---
+
+## SADRŽAJ
+
+1. [Šta je RabbitMQ i zašto ga koristimo](#1-šta-je-rabbitmq-i-zašto-ga-koristimo)
+2. [Šta je Saga pattern](#2-šta-je-saga-pattern)
+3. [Šta je Choreography vs Orchestration](#3-šta-je-choreography-vs-orchestration)
+4. [Koji problem rješavamo](#4-koji-problem-rješavamo)
+5. [Dizajn arhitekture i toka sage](#5-dizajn-arhitekture-i-toka-sage)
+6. [Dijagrami](#6-dijagrami)
+7. [RabbitMQ Exchange i Queue dizajn](#7-rabbitmq-exchange-i-queue-dizajn)
+8. [Implementacija — svaki fajl objašnjen](#8-implementacija--svaki-fajl-objašnjen)
+9. [Lokalne transakcije i međuzavisnost](#9-lokalne-transakcije-i-međuzavisnost)
+10. [Kompenzacijske (inverzne) akcije](#10-kompenzacijske-inverzne-akcije)
+11. [Finalno stanje sage](#11-finalno-stanje-sage)
+12. [Testovi — svaki test objašnjen](#12-testovi--svaki-test-objašnjen)
+13. [Kako pokrenuti RabbitMQ](#13-kako-pokrenuti-rabbitmq)
+14. [Live testiranje — korak po korak](#14-live-testiranje--korak-po-korak)
+15. [Provjera baze podataka](#15-provjera-baze-podataka)
+16. [Česta pitanja na odbrani](#16-česta-pitanja-na-odbrani)
+
+---
+
+## 1. Šta je RabbitMQ i zašto ga koristimo
+
+**RabbitMQ** je message broker — posrednik koji prima poruke od jednog servisa i dostavlja ih drugom. Servisi se ne direktno pozivaju (kao što Booking zove Payment putem Feign HTTP-a), već pišu poruke u RabbitMQ red čekanja (queue), a drugi servis te poruke čita kada je spreman.
+
+### Zašto asinkrono umjesto sinkronog Feign poziva?
+
+| Kriterij | Sinkrono (Feign/HTTP) | Asinkrono (RabbitMQ) |
+|---|---|---|
+| Zahtjev blokira | DA — klijent čeka odgovor | NE — odmah 202 Accepted |
+| Servis mora biti dostupan | DA — pad Paymenta = pad Bookinga | NE — poruka čeka u queuu |
+| Rollback na grešku | Kompleksan (catch/throw) | Event-driven kompenzacija |
+| Skalabilnost | Ograničena | Visoka — servisi nezavisno skaliraju |
+| Audit trail | Nema | Svaki event je zapis |
+
+U našem projektu već postoji sinkrona komunikacija (Z5 — `createOrchestrated()` koristi Feign). Sada dodajemo asinhronu alternativu koja je robusnija i realističnija za produkcijsko okruženje.
+
+---
+
+## 2. Šta je Saga pattern
+
+**Saga** je pattern za upravljanje distribuiranim transakcijama u mikroservisima.
+
+Klasična baza podataka ima **ACID transakciju** — ili sve prođe ili se sve poništi. U mikroservisima svaki servis ima **svoju bazu** — ne možemo imati jednu globalnu transakciju koja obuhvata više baza.
+
+**Saga rješava ovaj problem:**
+- Dijeli globalnu transakciju na **lokalne transakcije** (jedna po mikroservisu)
+- Svaka lokalna transakcija radi samo na svojoj bazi
+- Ako neka transakcija padne, prethodne se poništavaju putem **kompenzacijskih transakcija**
+
+```
+Globalna transakcija (nemoguća u mikroservisima):
+┌─────────────────────────────────────────────────────┐
+│  BEGIN;                                              │
+│    INSERT INTO booking_db.booking ...               │  ← Različite baze!
+│    INSERT INTO payment_db.payment ...               │  ← Nemoguće atomično
+│  COMMIT;  ← ili ROLLBACK sve                        │
+└─────────────────────────────────────────────────────┘
+
+Saga (moguće u mikroservisima):
+Lokalna TX 1 (booking_db): INSERT booking WHERE status=PENDING
+Lokalna TX 2 (payment_db): INSERT payment WHERE status=PAID
+  → Ako TX 2 padne: Kompenzacijska akcija TX 1: UPDATE booking SET status=CANCELLED
+```
+
+---
+
+## 3. Šta je Choreography vs Orchestration
+
+### Orchestration (centralni orkestrator)
+
+Postoji jedan servis koji zna cijeli tok i direktno poziva ostale:
+
+```
+[Saga Orkestrator]
+      │
+      ├──→ Booking Service: "Kreiraj booking"
+      │
+      ├──→ Payment Service: "Naplati"
+      │
+      └──→ User Service: "Dodaj loyalty poene"
+```
+
+**Mana:** Orkestrator postaje usko grlo i single point of failure.
+
+### Choreography (koreografija) — naš pristup
+
+Svaki servis zna samo šta radi i šta objavljuje/sluša. Nema centralnog koordinatora:
+
+```
+Booking Service ──[BookingCreatedEvent]──→ RabbitMQ ──→ Payment Service
+                                                              │
+                                                   [PaymentCompletedEvent]
+                                                              │
+                ←─────────────────────────── RabbitMQ ←──────┘
+                → UPDATE booking = CONFIRMED
+```
+
+**Prednost:** Svaki servis je nezavisan. Dodavanje novog koraka = dodavanje novog listenera, bez promjene postojećeg koda.
+
+---
+
+## 4. Koji problem rješavamo
+
+### Use case: Kreiranje rezervacije (booking) sa plaćanjem
+
+Korisnik želi rezervisati teren. Sistem mora:
+1. Kreirati rezervaciju (Booking Service, booking_db)
+2. Naplatiti (Payment Service, payment_db)
+3. Ako naplata ne uspije → rezervacija se mora otkazati
+4. Ako sve prođe → rezervacija se potvrdi (finalno stanje)
+
+Ovo su tačno **dvije lokalne transakcije u različitim mikroservisima koje međusobno ovise** — što zadatak zahtijeva.
+
+### Zašto ne možemo koristiti samo Feign (Z5)?
+
+U Z5 `createOrchestrated()` koristimo Feign koji radi dobro, ali:
+- Blokira HTTP thread dok Payment Service ne odgovori
+- Ako Payment Service kasni 10 sekundi, Booking Service thread čeka 10 sekundi
+- Ako Payment Service padne, cijeli zahtjev pada
+- Nema garantovane dostave poruke
+
+Sa RabbitMQ sagom:
+- Booking Service odmah vrati 202 Accepted
+- Poruka čeka u queuu dok Payment Service nije dostupan
+- Garantovana dostava (durable queues)
+
+---
+
+## 5. Dizajn arhitekture i toka sage
+
+### Stanja kroz cijelu sagu
+
+```
+BOOKING STATUS:  PENDING ──→ CONFIRMED  (sretni put — finalno)
+                 PENDING ──→ CANCELLED  (kompenzacija — finalno)
+
+PAYMENT STATUS:  PENDING ──→ PAID       (sretni put — lokalna TX 2)
+                 PENDING ──→ FAILED     (greška — lokalna TX 2)
+```
+
+### Sretni put (Happy Path)
+
+```
+Korak 1: Klijent pozove POST /api/bookings/saga
+Korak 2: Booking Service generiše sagaId (UUID), spremi Booking(status=PENDING)
+Korak 3: Booking Service pošalje BookingCreatedEvent na RabbitMQ
+Korak 4: Booking Service odmah vrati 202 Accepted klijentu
+Korak 5: Payment Service primi BookingCreatedEvent
+Korak 6: Payment Service spremi Payment(status=PENDING)
+Korak 7: Payment Service ažurira Payment(status=PAID)
+Korak 8: Payment Service pošalje PaymentCompletedEvent na RabbitMQ
+Korak 9: Booking Service primi PaymentCompletedEvent
+Korak 10: Booking Service ažurira Booking(status=CONFIRMED) ← FINALNO
+```
+
+### Kompenzacijski put (Payment ne uspije)
+
+```
+Koraci 1-5 isti kao gore
+Korak 6: Payment Service spremi Payment(status=PENDING)
+Korak 7: Payment Service detektuje grešku → ažurira Payment(status=FAILED)
+Korak 8: Payment Service pošalje PaymentFailedEvent na RabbitMQ
+Korak 9: Booking Service primi PaymentFailedEvent
+Korak 10: Booking Service ažurira Booking(status=CANCELLED) ← KOMPENZACIJA
+```
+
+---
+
+## 6. Dijagrami
+
+### 6.1 Sretni put (Happy Path)
+
+```
+┌──────────┐     ┌──────────────────┐     ┌──────────────┐     ┌──────────────────┐
+│ Klijent  │     │  Booking Service  │     │  RabbitMQ    │     │ Payment Service  │
+│          │     │  (booking_db)     │     │              │     │  (payment_db)    │
+└────┬─────┘     └────────┬─────────┘     └──────┬───────┘     └────────┬─────────┘
+     │                    │                       │                      │
+     │ POST /bookings/saga│                       │                      │
+     │──────────────────→ │                       │                      │
+     │                    │                       │                      │
+     │         ┌──────────┴──────────┐            │                      │
+     │         │  LOKALNA TX 1       │            │                      │
+     │         │  Booking → PENDING  │            │                      │
+     │         │  (INSERT booking_db)│            │                      │
+     │         └──────────┬──────────┘            │                      │
+     │                    │  BookingCreatedEvent   │                      │
+     │                    │  sagaId, bookingId,    │                      │
+     │                    │  amount, method        │                      │
+     │                    │───────────────────────→│                      │
+     │ 202 Accepted        │                       │  BookingCreatedEvent │
+     │ {id, status:PENDING}│                       │─────────────────────→│
+     │←─────────────────── │                       │                      │
+     │                    │                        │        ┌─────────────┴─────────────┐
+     │                    │                        │        │    LOKALNA TX 2            │
+     │                    │                        │        │  Payment → PENDING (INSERT)│
+     │                    │                        │        │  Payment → PAID (UPDATE)   │
+     │                    │                        │        └─────────────┬─────────────┘
+     │                    │                        │                      │
+     │                    │   PaymentCompletedEvent│                      │
+     │                    │   sagaId, paymentId,   │                      │
+     │                    │   transactionId        │  PaymentCompletedEvent
+     │                    │←───────────────────────│←─────────────────────│
+     │                    │                        │                      │
+     │         ┌──────────┴──────────┐             │                      │
+     │         │  Booking → CONFIRMED│             │                      │
+     │         │  (UPDATE booking_db)│             │                      │
+     │         │  ← FINALNO STANJE   │             │                      │
+     │         └─────────────────────┘             │                      │
+```
+
+### 6.2 Kompenzacijski put (Payment ne uspije)
+
+```
+┌──────────┐     ┌──────────────────┐     ┌──────────────┐     ┌──────────────────┐
+│ Klijent  │     │  Booking Service  │     │  RabbitMQ    │     │ Payment Service  │
+└────┬─────┘     └────────┬─────────┘     └──────┬───────┘     └────────┬─────────┘
+     │                    │                       │                      │
+     │ POST /bookings/saga?simulateFailure=true    │                      │
+     │──────────────────→ │                       │                      │
+     │                    │                       │                      │
+     │         ┌──────────┴──────────┐            │                      │
+     │         │  LOKALNA TX 1       │            │                      │
+     │         │  Booking → PENDING  │            │                      │
+     │         └──────────┬──────────┘            │                      │
+     │                    │  BookingCreatedEvent   │                      │
+     │                    │  (simulateFailure=true)│                      │
+     │                    │───────────────────────→│                      │
+     │ 202 Accepted        │                       │─────────────────────→│
+     │←─────────────────── │                       │                      │
+     │                    │                        │        ┌─────────────┴─────────────┐
+     │                    │                        │        │    LOKALNA TX 2 (GREŠKA)   │
+     │                    │                        │        │  Payment → PENDING (INSERT)│
+     │                    │                        │        │  Payment → FAILED (UPDATE) │
+     │                    │                        │        └─────────────┬─────────────┘
+     │                    │                        │                      │
+     │                    │   PaymentFailedEvent   │  PaymentFailedEvent  │
+     │                    │   sagaId, reason       │←─────────────────────│
+     │                    │←───────────────────────│                      │
+     │                    │                        │                      │
+     │         ┌──────────┴──────────────┐         │                      │
+     │         │  KOMPENZACIJSKA TX      │         │                      │
+     │         │  Booking → CANCELLED    │         │                      │
+     │         │  (UPDATE booking_db)    │         │                      │
+     │         │  ← INVERZNA AKCIJA      │         │                      │
+     │         └─────────────────────────┘         │                      │
+```
+
+### 6.3 RabbitMQ topology dijagram
+
+```
+                    ╔══════════════════════════════════════╗
+                    ║   sportcenter.saga.exchange          ║
+                    ║   (Topic Exchange, durable=true)     ║
+                    ╚══════════════════════════════════════╝
+                                     │
+              ┌──────────────────────┼──────────────────────┐
+              │                      │                      │
+    routing key:              routing key:          routing key:
+    booking.saga.created    payment.saga.completed  payment.saga.failed
+              │                      │                      │
+              ▼                      ▼                      ▼
+    ┌─────────────────┐    ┌──────────────────┐   ┌──────────────────┐
+    │ sportcenter.     │    │ sportcenter.      │   │ sportcenter.     │
+    │ booking.created  │    │ payment.completed │   │ payment.failed   │
+    │ .queue           │    │ .queue            │   │ .queue           │
+    │ (durable)        │    │ (durable)         │   │ (durable)        │
+    └────────┬─────────┘    └────────┬──────────┘   └────────┬─────────┘
+             │                       │                        │
+             ▼                       ▼                        ▼
+    ┌─────────────────┐    ┌──────────────────┐   ┌──────────────────┐
+    │ KONZUMIRA:       │    │ KONZUMIRA:        │   │ KONZUMIRA:       │
+    │ Payment Service  │    │ Booking Service   │   │ Booking Service  │
+    │ PaymentSaga      │    │ BookingSaga       │   │ BookingSaga      │
+    │ Consumer         │    │ Consumer          │   │ Consumer         │
+    └─────────────────┘    └──────────────────┘   └──────────────────┘
+```
+
+---
+
+## 7. RabbitMQ Exchange i Queue dizajn
+
+### Exchange
+
+**Topic Exchange** (`sportcenter.saga.exchange`, durable=true)
+
+Topic exchange dozvoljava rutiranje poruka prema **routing key** koji može sadržavati wildcard znakove (`*` = jedna riječ, `#` = više riječi). Npr. `booking.saga.*` bi uhvatio i `booking.saga.created` i `booking.saga.updated`.
+
+Koristimo `durable=true` — exchange preživljava restart RabbitMQ servera.
+
+### Queues
+
+| Queue | Durable | Ko objavljuje | Ko konzumira |
+|---|---|---|---|
+| `sportcenter.booking.created.queue` | DA | Booking Service | Payment Service |
+| `sportcenter.payment.completed.queue` | DA | Payment Service | Booking Service |
+| `sportcenter.payment.failed.queue` | DA | Payment Service | Booking Service |
+
+`durable=true` znači da queue preživljava restart RabbitMQ-a i poruke se ne gube.
+
+### Routing Keys
+
+| Routing Key | Šalje | Smjer |
+|---|---|---|
+| `booking.saga.created` | Booking Service | → Payment Service |
+| `payment.saga.completed` | Payment Service | → Booking Service |
+| `payment.saga.failed` | Payment Service | → Booking Service |
+
+### Bindings
+
+Binding je veza između exchangea i queuea za određeni routing key:
+
+```
+EXCHANGE ──[booking.saga.created]──→ sportcenter.booking.created.queue
+EXCHANGE ──[payment.saga.completed]──→ sportcenter.payment.completed.queue
+EXCHANGE ──[payment.saga.failed]──→ sportcenter.payment.failed.queue
+```
+
+### JSON Serialization
+
+Koristimo `Jackson2JsonMessageConverter` — poruke se serijalizuju u JSON format:
+
+```json
+{
+  "sagaId": "a3f7b2c1-4d5e-6f7a-8b9c-0d1e2f3a4b5c",
+  "bookingId": 42,
+  "userId": 1,
+  "facilityId": 2,
+  "startTime": "2026-06-01T10:00:00",
+  "endTime": "2026-06-01T12:00:00",
+  "totalPrice": 150.00,
+  "paymentMethod": "CREDIT_CARD",
+  "simulateFailure": false,
+  "timestamp": "2026-05-12T21:00:00"
+}
+```
+
+---
+
+## 8. Implementacija — svaki fajl objašnjen
+
+### 8.1 Booking Service novi fajlovi
+
+#### `config/RabbitMQConfig.java`
+
+```java
+@Configuration
+public class RabbitMQConfig {
+    // Definiše exchange, queues i bindings kao Spring Beans
+    // Spring Boot ih automatski kreira u RabbitMQ pri startu
+    
+    public static final String SAGA_EXCHANGE = "sportcenter.saga.exchange";
+    // ... konstante za queue nazive i routing keyeve
+    
+    @Bean TopicExchange sagaExchange() { ... }
+    @Bean Queue paymentCompletedQueue() { ... }
+    @Bean Queue paymentFailedQueue() { ... }
+    @Bean Queue bookingCreatedQueue() { ... }  // deklariran ovdje da RabbitMQ ga kreira
+    @Bean Binding bookingCreatedBinding() { ... }
+    @Bean Binding paymentCompletedBinding() { ... }
+    @Bean Binding paymentFailedBinding() { ... }
+    @Bean MessageConverter jsonMessageConverter() { 
+        return new Jackson2JsonMessageConverter(); // JSON umjesto binarnog formata
+    }
+}
+```
+
+**Zašto deklariramo `bookingCreatedQueue` i u Booking Serviceu?**
+RabbitMQ kreira queue tek kada neki servis deklarira da želi da ga koristi. Ako Payment Service nije pokrenut, a Booking Service pošalje poruku, RabbitMQ bi vratio grešku ako queue ne postoji. Declariranjem u oba servisa osiguravamo da queue uvijek postoji.
+
+---
+
+#### `saga/event/BookingCreatedEvent.java`
+
+```java
+@Data @NoArgsConstructor @AllArgsConstructor @Builder
+public class BookingCreatedEvent {
+    private String sagaId;       // UUID koji prati ovu instancu sage kroz sve evente
+    private Long bookingId;      // ID kreirane rezervacije
+    private Long userId;         // Korisnički ID
+    private Long facilityId;     // ID terena
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+    private BigDecimal totalPrice;
+    private String paymentMethod; // CREDIT_CARD | DEBIT_CARD | PAYPAL
+    private LocalDateTime timestamp;
+    private boolean simulateFailure; // Za testiranje kompenzacijske putanje
+}
+```
+
+**Zašto `sagaId`?**
+`sagaId` je UUID koji se generiše pri pokretanju sage i prenosi kroz sve evente. Svi logovi koriste `[SAGA][sagaId]` prefix — ovo omogućava praćenje jedne konkretne sage kroz logove više servisa. Npr. u Production sistemu možemo u centralizovanim logovima (ELK stack) filtrirati po `sagaId` i vidjeti kompletan tok.
+
+**Zašto `simulateFailure`?**
+Ovo polje nam dozvoljava da testiramo kompenzacijsku putanju bez mijenjanja business logike. Kada ga postavimo na `true`, Payment Service namjerno neće uspjeti u plaćanju. Ovo je standardan pattern za testiranje Saga kompenzacije.
+
+---
+
+#### `saga/event/PaymentCompletedEvent.java`
+
+```java
+@Data @NoArgsConstructor @AllArgsConstructor @Builder
+public class PaymentCompletedEvent {
+    private String sagaId;
+    private Long bookingId;       // Koji booking potvrditi
+    private Long paymentId;       // ID kreiranog paymenta (za vezu booking↔payment)
+    private String transactionId; // TXN-SAGA-XXXXXXXX (za audit)
+    private BigDecimal amount;
+    private LocalDateTime timestamp;
+}
+```
+
+---
+
+#### `saga/event/PaymentFailedEvent.java`
+
+```java
+@Data @NoArgsConstructor @AllArgsConstructor @Builder
+public class PaymentFailedEvent {
+    private String sagaId;
+    private Long bookingId;  // Koji booking otkazati
+    private String reason;   // "Card declined" / "Insufficient funds" / ...
+    private LocalDateTime timestamp;
+}
+```
+
+---
+
+#### `saga/BookingSagaPublisher.java`
+
+```java
+@Component @RequiredArgsConstructor
+public class BookingSagaPublisher {
+    private final RabbitTemplate rabbitTemplate;
+    
+    public void publishBookingCreated(BookingCreatedEvent event) {
+        rabbitTemplate.convertAndSend(
+            SAGA_EXCHANGE,           // Naziv exchangea
+            BOOKING_CREATED_KEY,     // Routing key: "booking.saga.created"
+            event                    // Serializovano kao JSON
+        );
+    }
+}
+```
+
+`RabbitTemplate.convertAndSend()` serijalizuje Java objekat u JSON i šalje ga na exchange sa zadanim routing keyem. Exchange zatim rutuira poruku u odgovarajući queue prema binding pravilima.
+
+---
+
+#### `saga/BookingSagaConsumer.java`
+
+```java
+@Component @RequiredArgsConstructor
+public class BookingSagaConsumer {
+    private final BookingSagaService bookingSagaService;
+    
+    @RabbitListener(queues = RabbitMQConfig.PAYMENT_COMPLETED_QUEUE)
+    public void onPaymentCompleted(PaymentCompletedEvent event) {
+        bookingSagaService.confirmBooking(event);
+    }
+    
+    @RabbitListener(queues = RabbitMQConfig.PAYMENT_FAILED_QUEUE)
+    public void onPaymentFailed(PaymentFailedEvent event) {
+        bookingSagaService.cancelBooking(event);
+    }
+}
+```
+
+`@RabbitListener` anotacija govori Springu da ova metoda treba biti pozvana kada poruka stigne u navedeni queue. Spring automatski deserijalizuje JSON u odgovarajući Java objekat. Ovo je asinhrono — metoda se poziva u zasebnom threadu kada poruka stigne.
+
+---
+
+#### `service/BookingSagaService.java`
+
+Ovo je srce Booking Servicea u sagi. Ima 3 metode:
+
+**`initiate()` — Lokalna TX 1:**
+```java
+@Transactional
+public BookingResponseDTO initiate(BookingRequestDTO dto, String paymentMethod, boolean simulateFailure) {
+    // 1. Generiši sagaId
+    String sagaId = UUID.randomUUID().toString();
+    
+    // 2. LOKALNA TRANSAKCIJA 1: spremi Booking kao PENDING
+    Booking booking = bookingRepository.save(Booking.builder()
+        .status(Booking.BookingStatus.PENDING)
+        .build());
+    
+    // 3. Pošalji event na RabbitMQ (van transakcije — best effort)
+    publisher.publishBookingCreated(BookingCreatedEvent.builder()
+        .sagaId(sagaId)
+        .bookingId(booking.getId())
+        // ... ostala polja
+        .build());
+    
+    // 4. Odmah vrati odgovor klijentu (202 Accepted)
+    return modelMapper.map(booking, BookingResponseDTO.class);
+}
+```
+
+**VAŽNA NAPOMENA:** `@Transactional` pokriva samo bazu — `bookingRepository.save()`. Publisher poziv (`publishBookingCreated`) nije unutar DB transakcije. U realnom produkcijskom sistemu koristio bi se **Transactional Outbox pattern** da garantuje da se event pošalje samo ako se DB transakcija uspješno commituje. Za ovaj zadatak, pristup je dovoljno korektan.
+
+**`confirmBooking()` — Finalno stanje:**
+```java
+@Transactional
+public void confirmBooking(PaymentCompletedEvent event) {
+    Booking booking = bookingRepository.findById(event.getBookingId())...;
+    
+    // Idempotentnost: ignoriši ako nije PENDING
+    if (booking.getStatus() != Booking.BookingStatus.PENDING) return;
+    
+    booking.setStatus(Booking.BookingStatus.CONFIRMED); // FINALNO STANJE
+    bookingRepository.save(booking);
+}
+```
+
+**`cancelBooking()` — Kompenzacijska (inverzna) akcija:**
+```java
+@Transactional
+public void cancelBooking(PaymentFailedEvent event) {
+    Booking booking = bookingRepository.findById(event.getBookingId())...;
+    
+    // Idempotentnost
+    if (booking.getStatus() != Booking.BookingStatus.PENDING) return;
+    
+    booking.setStatus(Booking.BookingStatus.CANCELLED); // INVERZNA AKCIJA
+    bookingRepository.save(booking);
+}
+```
+
+**Zašto idempotentnost?**
+RabbitMQ garantuje "at-least-once delivery" — poruka može biti dostavljena više puta (npr. ako servis padne prije potvrdnog ACK-a). Idempotentnost osigurava da duplirana isporuka ne napravi grešku (ne mijenjamo booking koji je već CONFIRMED ili CANCELLED).
+
+---
+
+#### `controller/BookingSagaController.java`
+
+```java
+@RestController
+@RequestMapping("/api/bookings")
+public class BookingSagaController {
+    
+    @PostMapping("/saga")
+    public ResponseEntity<BookingResponseDTO> createViaSaga(
+            @Valid @RequestBody BookingRequestDTO dto,
+            @RequestParam(defaultValue = "CREDIT_CARD") String paymentMethod,
+            @RequestParam(defaultValue = "false") boolean simulateFailure) {
+        
+        BookingResponseDTO response = bookingSagaService.initiate(dto, paymentMethod, simulateFailure);
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(response);
+        //     ↑ 202 Accepted (ne 201 Created) jer akcija NIJE završena
+    }
+}
+```
+
+**Zašto 202 Accepted a ne 200/201?**
+HTTP 202 Accepted znači "zahtjev je primljen i bit će obrađen, ali obrada još nije završena". Ovo je semantički ispravno za async operacije — booking je kreiran (PENDING), ali konačni ishod (CONFIRMED/CANCELLED) još nije poznat.
+
+---
+
+### 8.2 Payment Service novi fajlovi
+
+Struktura je simetrična Booking Serviceu.
+
+#### `config/RabbitMQConfig.java`
+
+Identična konfiguracija kao u Booking Serviceu — oba servisa moraju imati konzistentnu definiciju exchangea i queues.
+
+---
+
+#### `service/PaymentSagaService.java`
+
+```java
+@Service @RequiredArgsConstructor
+public class PaymentSagaService {
+    private final PaymentRepository paymentRepository;
+    private final PaymentSagaPublisher publisher;
+    
+    @Transactional
+    public void processPayment(BookingCreatedEvent event) {
+        // 1. Mapiranje paymentMethod
+        Payment.PaymentMethod method;
+        try {
+            method = Payment.PaymentMethod.valueOf(event.getPaymentMethod());
+        } catch (IllegalArgumentException e) {
+            method = Payment.PaymentMethod.CREDIT_CARD; // fallback za nepoznate metode
+        }
+        
+        // 2. LOKALNA TX 2 — korak A: spremi Payment PENDING
+        Payment payment = paymentRepository.save(Payment.builder()
+            .bookingId(event.getBookingId())
+            .amount(event.getTotalPrice())
+            .paymentMethod(method)
+            .transactionId("TXN-SAGA-" + UUID.randomUUID()...)
+            .status(Payment.PaymentStatus.PENDING)
+            .build());
+        
+        // 3. Simulacija greške (za testiranje)
+        if (event.isSimulateFailure()) {
+            payment.setStatus(Payment.PaymentStatus.FAILED);
+            paymentRepository.save(payment);
+            // KOMPENZACIJSKA PORUKA → Booking Service će otkazati booking
+            publisher.publishPaymentFailed(PaymentFailedEvent.builder()
+                .sagaId(event.getSagaId())
+                .bookingId(event.getBookingId())
+                .reason("Simulated payment failure")
+                .build());
+            return;
+        }
+        
+        // 4. LOKALNA TX 2 — korak B: ažuruj Payment u PAID
+        try {
+            payment.setStatus(Payment.PaymentStatus.PAID);
+            payment.setPaidAt(LocalDateTime.now());
+            Payment saved = paymentRepository.save(payment);
+            
+            // USPJEŠNA PORUKA → Booking Service će potvrditi booking
+            publisher.publishPaymentCompleted(PaymentCompletedEvent.builder()
+                .sagaId(event.getSagaId())
+                .bookingId(event.getBookingId())
+                .paymentId(saved.getId())
+                .transactionId(saved.getTransactionId())
+                .amount(saved.getAmount())
+                .build());
+        } catch (Exception ex) {
+            // NEOČEKIVANA GREŠKA → kompenzacija
+            payment.setStatus(Payment.PaymentStatus.FAILED);
+            paymentRepository.save(payment);
+            publisher.publishPaymentFailed(...);
+        }
+    }
+}
+```
+
+**Zašto dva `paymentRepository.save()` poziva?**
+- **Prvi save (PENDING):** Kreira payment zapis odmah — audit trail, korisnik može vidjeti da je plaćanje u toku
+- **Drugi save (PAID/FAILED):** Ažurira status nakon procesiranja
+
+Ovo je namjerno — u realnom sistemu između ova dva koraka bio bi poziv payment gateway servisu (Stripe, PayPal...).
+
+---
+
+#### `saga/PaymentSagaConsumer.java`
+
+```java
+@Component @RequiredArgsConstructor
+public class PaymentSagaConsumer {
+    private final PaymentSagaService paymentSagaService;
+    
+    @RabbitListener(queues = RabbitMQConfig.BOOKING_CREATED_QUEUE)
+    public void onBookingCreated(BookingCreatedEvent event) {
+        paymentSagaService.processPayment(event);
+    }
+}
+```
+
+---
+
+### 8.3 Infrastrukturni fajlovi
+
+#### `docker-compose.yml` — dodan RabbitMQ
+
+```yaml
+rabbitmq:
+  image: rabbitmq:3.13-management
+  container_name: sportcenter-rabbitmq
+  environment:
+    RABBITMQ_DEFAULT_USER: guest
+    RABBITMQ_DEFAULT_PASS: guest
+  ports:
+    - "5672:5672"   # AMQP protokol — servisi se spajaju ovdje
+    - "15672:15672" # Management UI — web sučelje za monitoring
+  volumes:
+    - rabbitmq-data:/var/lib/rabbitmq  # durable storage
+  healthcheck:
+    test: ["CMD", "rabbitmq-diagnostics", "ping"]
+```
+
+**Zašto `rabbitmq:3.13-management`?**
+`management` tag uključuje web UI za monitoring na portu 15672. Bez njega možemo koristiti samo AMQP (5672) bez grafičkog sučelja.
+
+#### `application.properties` — oba servisa
+
+```properties
+spring.rabbitmq.host=${RABBITMQ_HOST:localhost}
+spring.rabbitmq.port=${RABBITMQ_PORT:5672}
+spring.rabbitmq.username=${RABBITMQ_USER:guest}
+spring.rabbitmq.password=${RABBITMQ_PASS:guest}
+spring.rabbitmq.virtual-host=/
+```
+
+Spring Boot automatski konfigurira `RabbitTemplate` i `SimpleMessageListenerContainer` na osnovu ovih propertyja.
+
+#### `pom.xml` — oba servisa
+
+```xml
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-amqp</artifactId>
+</dependency>
+<dependency>
+    <groupId>org.springframework.amqp</groupId>
+    <artifactId>spring-rabbit-test</artifactId>
+    <scope>test</scope>
+</dependency>
+```
+
+`spring-boot-starter-amqp` uključuje:
+- `spring-amqp` — core AMQP abstrakcije
+- `spring-rabbit` — RabbitMQ implementacija
+- Auto-konfiguracija (`RabbitAutoConfiguration`)
+
+---
+
+## 9. Lokalne transakcije i međuzavisnost
+
+### Lokalna transakcija 1 (Booking Service — `booking_db`)
+
+| Aspekt | Detalj |
+|---|---|
+| **Gdje** | `BookingSagaService.initiate()` |
+| **Šta** | `INSERT INTO booking (user_id, facility_id, ..., status='PENDING')` |
+| **Baza** | `sportcenter_booking_db`, tabela `booking` |
+| **Anotacija** | `@Transactional` |
+| **Na DB grešku** | Automatski rollback (Spring @Transactional) — booking se ne spremi |
+| **Na uspjeh** | Pošalje `BookingCreatedEvent` na RabbitMQ |
+
+### Lokalna transakcija 2 (Payment Service — `payment_db`)
+
+| Aspekt | Detalj |
+|---|---|
+| **Gdje** | `PaymentSagaService.processPayment()` |
+| **Šta** | `INSERT INTO payment (..., status='PENDING')` → `UPDATE payment SET status='PAID'` |
+| **Baza** | `sportcenter_payment_db`, tabela `payment` |
+| **Anotacija** | `@Transactional` |
+| **Na uspjeh** | Pošalje `PaymentCompletedEvent` → TX1 se finalizuje (CONFIRMED) |
+| **Na grešku** | Pošalje `PaymentFailedEvent` → TX1 se kompenzuje (CANCELLED) |
+
+### Međuzavisnost
+
+```
+TX1 ne može biti CONFIRMED bez da TX2 prođe.
+TX2 ne može biti procesirana bez TX1 (koristi bookingId iz TX1).
+
+TX1 USPJEH + TX2 USPJEH = FINALNO (CONFIRMED + PAID)
+TX1 USPJEH + TX2 GREŠKA  = KOMPENZACIJA (CANCELLED + FAILED)
+TX1 GREŠKA               = TX2 se nikada ne pokrene (event se ne pošalje)
+```
+
+---
+
+## 10. Kompenzacijske (inverzne) akcije
+
+### Šta je kompenzacijska transakcija?
+
+U distribuiranim sistemima ne možemo "rollbackovati" tuđu bazu. Umjesto toga, eksplicitno pišemo inverznu operaciju.
+
+| Originalna akcija | Kompenzacijska akcija |
+|---|---|
+| `INSERT booking, status=PENDING` | `UPDATE booking SET status=CANCELLED` |
+| `INSERT payment, status=PENDING` | `UPDATE payment SET status=FAILED` |
+
+### Zašto ne brišemo (DELETE)?
+
+- **Audit trail** — sistem mora imati historiju šta se desilo
+- **Debugging** — ako je booking CANCELLED, može se vidjeti zašto
+- **Idempotentnost** — lakše je provjeriti stanje nego detektovati duplikate
+
+### Tko okida kompenzaciju?
+
+1. Payment Service detektuje grešku → šalje `PaymentFailedEvent`
+2. Booking Service prima `PaymentFailedEvent` → poziva `cancelBooking()` → `CANCELLED`
+
+Ovo je **obostrana ovisnost**:
+- Ako TX2 padne → TX1 se kompenzuje
+- Ako TX1 padne (DB greška) → TX2 se nikada ne pokrene (event nije poslan)
+
+---
+
+## 11. Finalno stanje sage
+
+Saga je završena (i označena kao finalna) kada su oba ova uslova ispunjena:
+
+1. `Booking.status = CONFIRMED` (u `booking_db`)
+2. `Payment.status = PAID` (u `payment_db`)
+
+Ovo se dešava kada:
+1. TX1 uspješno kreira Booking(PENDING)
+2. TX2 uspješno kreira Payment(PENDING → PAID)
+3. `PaymentCompletedEvent` stigao do Booking Servicea
+4. Booking ažuriran na CONFIRMED
+
+Logovi pri finalnom stanju:
+```
+[SAGA][abc-123] Booking id=42 CONFIRMED — saga COMPLETE (paymentId=99, txn=TXN-SAGA-ABC12345)
+```
+
+---
+
+## 12. Testovi — svaki test objašnjen
+
+### 12.1 `BookingSagaServiceTest.java` (9 testova)
+
+Testira logiku `BookingSagaService` — Booking Service strana sage.
+
+#### Test 1: `initiate_savesBookingAsPending_andPublishesEvent`
+```
+Šta testira: Sretni put pokretanja sage
+Ulaz: Validan BookingRequestDTO
+Provjere:
+  - bookingRepository.save() pozvan sa PENDING statusom
+  - publisher.publishBookingCreated() pozvan jednom
+  - Event sadrži ispravan bookingId i sagaId != null
+  - simulateFailure = false
+Zašto: Ovo je centralni slučaj upotrebe — mora raditi ispravno
+```
+
+#### Test 2: `initiate_withSimulateFailure_publishesEventWithSimulateFlagTrue`
+```
+Šta testira: Prosljeđivanje simulateFailure flaga
+Ulaz: BookingRequestDTO, simulateFailure=true
+Provjere: event.isSimulateFailure() == true
+Zašto: Mora osigurati da se flag prosljeđuje bez promjene
+```
+
+#### Test 3: `initiate_throwsIllegalArgument_whenEndTimeBeforeStartTime`
+```
+Šta testira: Validacija datuma
+Ulaz: endTime < startTime
+Provjere: throws IllegalArgumentException, publisher NIJE pozvan
+Zašto: Ne smijemo kreirati nevaljani booking u bazi
+```
+
+#### Test 4: `confirmBooking_updatesStatusToConfirmed`
+```
+Šta testira: Sretni put potvrde bookinga (happy path final state)
+Ulaz: PaymentCompletedEvent za booking koji je PENDING
+Provjere: bookingRepository.save() sa statusom CONFIRMED
+Zašto: Ovo je finalno stanje — mora biti ispravno
+```
+
+#### Test 5: `confirmBooking_isIdempotent_whenAlreadyConfirmed`
+```
+Šta testira: Idempotentnost pri duplikatnoj poruci
+Ulaz: PaymentCompletedEvent za booking koji je već CONFIRMED
+Provjere: bookingRepository.save() NIJE pozvan
+Zašto: RabbitMQ at-least-once delivery — duplikati su mogući
+```
+
+#### Test 6: `confirmBooking_throwsResourceNotFoundException_whenBookingMissing`
+```
+Šta testira: Error handling kada booking nije u bazi
+Ulaz: PaymentCompletedEvent sa nepostojećim bookingId
+Provjere: throws ResourceNotFoundException
+Zašto: Edge case koji mora biti obrađen
+```
+
+#### Test 7: `cancelBooking_compensatingTransaction_updatesStatusToCancelled`
+```
+Šta testira: KOMPENZACIJSKA TRANSAKCIJA — ključni test zadatka
+Ulaz: PaymentFailedEvent za PENDING booking
+Provjere: bookingRepository.save() sa statusom CANCELLED
+Zašto: Ovo je inverzna akcija — srž zahtjeva zadatka
+```
+
+#### Test 8: `cancelBooking_isIdempotent_whenAlreadyCancelled`
+```
+Šta testira: Idempotentnost kompenzacije
+Ulaz: PaymentFailedEvent za već CANCELLED booking
+Provjere: bookingRepository.save() NIJE pozvan
+Zašto: Isti razlog kao Test 5
+```
+
+#### Test 9: `cancelBooking_throwsResourceNotFoundException_whenBookingMissing`
+```
+Šta testira: Error handling u kompenzaciji
+Ulaz: PaymentFailedEvent sa nepostojećim bookingId
+Provjere: throws ResourceNotFoundException
+```
+
+---
+
+### 12.2 `PaymentSagaServiceTest.java` (6 testova — ali PaymentSagaServiceTest ima 5 @Test metoda)
+
+Testira logiku `PaymentSagaService` — Payment Service strana sage.
+
+#### Test 1: `processPayment_happyPath_savesPaymentAsPaid_andPublishesCompletedEvent`
+```
+Šta testira: Sretni put procesiranja plaćanja
+Ulaz: BookingCreatedEvent, simulateFailure=false
+Provjere:
+  - 2 save() poziva: prvi PENDING, drugi PAID
+  - publisher.publishPaymentCompleted() pozvan sa ispravnim podacima
+  - publisher.publishPaymentFailed() NIJE pozvan
+Zašto: Osnovna funkcionalnost
+```
+
+#### Test 2: `processPayment_happyPath_transactionIdHasSagaPrefix`
+```
+Šta testira: Format transactionId
+Provjere: transactionId.startsWith("TXN-SAGA-")
+Zašto: Razlikovanje saga paymenta od regularnih plaćanja (audit)
+```
+
+#### Test 3: `processPayment_withSimulateFailure_savesPaymentAsFailed_andPublishesFailedEvent`
+```
+Šta testira: KOMPENZACIJSKA PUTANJA — payment greška
+Ulaz: BookingCreatedEvent, simulateFailure=true
+Provjere:
+  - 2 save() poziva: PENDING, pa FAILED
+  - publisher.publishPaymentFailed() pozvan ← trigguje kompenzaciju u Booking Serviceu
+  - publisher.publishPaymentCompleted() NIJE pozvan
+Zašto: Ovo je kompenzacijska grana — mora aktivirati inverznu akciju
+```
+
+#### Test 4: `processPayment_onUnexpectedException_publishesPaymentFailedEvent`
+```
+Šta testira: Neočekivana greška (npr. DB connectivity)
+Ulaz: BookingCreatedEvent, drugi save() baca RuntimeException
+Provjere: publishPaymentFailed() pozvan sa razlogom koji sadrži grešku
+Zašto: Robustnost — čak i neočekivane greške moraju okidati kompenzaciju
+```
+
+#### Test 5: `processPayment_unknownPaymentMethod_defaultsToCreditCard`
+```
+Šta testira: Nepoznati paymentMethod string
+Ulaz: paymentMethod = "BITCOIN" (nepostoji u enumu)
+Provjere: Payment spreman sa CREDIT_CARD metodom
+Zašto: Tolerantnost na nevaljane inpute
+```
+
+---
+
+### 12.3 `BookingServiceApplicationTests.java` i `PaymentServiceApplicationTests.java`
+
+```java
+@SpringBootTest
+@ActiveProfiles("test")
+class BookingServiceApplicationTests {
+    @MockBean
+    private RabbitTemplate rabbitTemplate; // Mock da context može da se loada
+    
+    @Test
+    void contextLoads() { }
+}
+```
+
+Ovi testovi provjeravaju da li se cijeli Spring kontekst može pokrenuti sa test konfiguracijom (H2 in-memory baza, bez prave MySQL i RabbitMQ konekcije).
+
+**Zašto `@MockBean RabbitTemplate`?**
+`@SpringBootTest` loada cijeli kontekst koji uključuje naše saga klase. `BookingSagaPublisher` zahtijeva `RabbitTemplate`. Bez njega, kontekst bi pao jer nema pravog RabbitMQ servera. `@MockBean` kreira mock implementaciju koja se ubrizgava umjesto prave.
+
+---
+
+## 13. Kako pokrenuti RabbitMQ
+
+### Preduvjet: Docker
+
+```bash
+# Provjeri da Docker radi
+docker --version
+docker compose version
+```
+
+### Korak 1: Kreirati/ažurirati .env
+
+```bash
+# Ako već postoji .env, dodaj RabbitMQ varijable:
+echo "RABBITMQ_HOST=localhost" >> .env
+echo "RABBITMQ_PORT=5672" >> .env
+echo "RABBITMQ_MGMT_PORT=15672" >> .env
+echo "RABBITMQ_USER=guest" >> .env
+echo "RABBITMQ_PASS=guest" >> .env
+```
+
+### Korak 2: Pokrenuti RabbitMQ putem Docker Compose
+
+```bash
+# Samo RabbitMQ
+docker compose up rabbitmq -d
+
+# Ili sve zajedno (MySQL + RabbitMQ)
+docker compose up -d
+```
+
+### Korak 3: Provjera
+
+```bash
+# Provjeri da li RabbitMQ radi
+docker compose ps
+
+# Treba pisati: sportcenter-rabbitmq   running (healthy)
+```
+
+### Korak 4: Management UI
+
+Otvoriti u browseru: **http://localhost:15672**
+
+- Username: `guest`
+- Password: `guest`
+
+U "Queues" tabu treba vidjeti sve 3 queues nakon što pokrenete servise.
+
+---
+
+## 14. Live testiranje — korak po korak
+
+### Priprema
+
+1. **Pokrenuti Docker** (MySQL + RabbitMQ):
+```bash
+docker compose up -d
+```
+
+2. **Buildati servise**:
+```bash
+cd "Booking Service" && ./mvnw clean package -DskipTests && cd ..
+cd "Payment Service" && ./mvnw clean package -DskipTests && cd ..
+```
+
+3. **Pokrenuti servise** (svaki u zasebnom terminalu):
+```bash
+# Terminal 1
+cd "Booking Service" && java -jar target/booking-service-0.0.1-SNAPSHOT.jar
+
+# Terminal 2
+cd "Payment Service" && java -jar target/payment-service-0.0.1-SNAPSHOT.jar
+```
+
+4. **Pričekati** dok oba servisa ne budu `Started ... in X seconds`.
+
+---
+
+### Test 1: Sretni put (Happy Path)
+
+**Zahtjev:**
+```bash
+curl -X POST http://localhost:8083/api/bookings/saga \
+  -H "Content-Type: application/json" \
+  -d '{
+    "userId": 1,
+    "facilityId": 1,
+    "startTime": "2026-07-01T10:00:00",
+    "endTime": "2026-07-01T12:00:00",
+    "totalPrice": 150.00
+  }'
+```
+
+**Očekivani HTTP odgovor (202 Accepted):**
+```json
+{
+  "id": 1,
+  "userId": 1,
+  "facilityId": 1,
+  "startTime": "2026-07-01T10:00:00",
+  "endTime": "2026-07-01T12:00:00",
+  "totalPrice": 150.00,
+  "status": "PENDING",
+  "createdAt": "2026-05-12T..."
+}
+```
+
+**Šta sad posmatrati u logovima Booking Servicea (Terminal 1):**
+```
+[SAGA][uuid...] Local txn 1 complete — Booking saved id=1 status=PENDING
+[SAGA][uuid...] Publishing BookingCreatedEvent for bookingId=1
+```
+
+**Šta sad posmatrati u logovima Payment Servicea (Terminal 2):**
+```
+[SAGA][uuid...] Received BookingCreatedEvent for bookingId=1 amount=150.00
+[SAGA][uuid...] Local txn 2 start — processing payment for bookingId=1
+[SAGA][uuid...] Payment saved id=1 status=PENDING transactionId=TXN-SAGA-XXXXXXXX
+[SAGA][uuid...] Payment id=1 PAID — publishing PaymentCompletedEvent
+```
+
+**Šta sad posmatrati u logovima Booking Servicea:**
+```
+[SAGA][uuid...] Received PaymentCompletedEvent for bookingId=1 paymentId=1
+[SAGA][uuid...] Booking id=1 CONFIRMED — saga COMPLETE
+```
+
+**Provjera finjalnog stanja:**
+```bash
+# Provjeri booking status
+curl http://localhost:8083/api/bookings/1
+# → status: "CONFIRMED"
+
+# Provjeri payment
+curl http://localhost:8084/api/payments/booking/1
+# → status: "PAID", transactionId: "TXN-SAGA-..."
+```
+
+---
+
+### Test 2: Kompenzacijska transakcija (simulirani failure)
+
+**Zahtjev:**
+```bash
+curl -X POST "http://localhost:8083/api/bookings/saga?simulateFailure=true" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "userId": 1,
+    "facilityId": 1,
+    "startTime": "2026-07-02T10:00:00",
+    "endTime": "2026-07-02T12:00:00",
+    "totalPrice": 150.00
+  }'
+```
+
+**Logovi Payment Servicea:**
+```
+[SAGA][uuid...] Received BookingCreatedEvent for bookingId=2 amount=150.00
+[SAGA][uuid...] Payment id=2 FAILED (simulated) — publishing PaymentFailedEvent
+```
+
+**Logovi Booking Servicea:**
+```
+[SAGA][uuid...] Received PaymentFailedEvent for bookingId=2 reason=Simulated payment failure...
+[SAGA][uuid...] Booking id=2 CANCELLED (compensating txn) — reason: Simulated...
+```
+
+**Provjera:**
+```bash
+curl http://localhost:8083/api/bookings/2
+# → status: "CANCELLED"   ← INVERZNA AKCIJA USPJEŠNA
+
+curl http://localhost:8084/api/payments/booking/2  
+# → status: "FAILED"
+```
+
+---
+
+### Test 3: Provjera kroz RabbitMQ Management UI
+
+1. Otvoriti **http://localhost:15672**
+2. Logirati se sa `guest` / `guest`
+3. Idi na **Queues** tab
+4. Provjeri 3 queues:
+   - `sportcenter.booking.created.queue` — Ready: 0 (sve procesovano)
+   - `sportcenter.payment.completed.queue` — Ready: 0
+   - `sportcenter.payment.failed.queue` — Ready: 0
+
+Ako queue ima poruke (Ready > 0), servis koji konzumira nije pokrenut ili je pao.
+
+5. Idi na **Exchanges** tab → `sportcenter.saga.exchange` → vidi bindings
+
+---
+
+### Test 4: Pokrenuti unit testove
+
+```bash
+# Booking Service
+cd "Booking Service"
+./mvnw test -Dspring.profiles.active=test
+# Rezultat: Tests run: 52, Failures: 0, Errors: 0, Skipped: 0
+
+# Payment Service
+cd "Payment Service"
+./mvnw test -Dspring.profiles.active=test
+# Rezultat: Tests run: 30, Failures: 0, Errors: 0, Skipped: 0
+```
+
+---
+
+### Test 5: Swagger UI
+
+Booking Service Swagger dostupan na: **http://localhost:8083/swagger-ui.html**
+
+Traži `Booking Saga` sekciju i endpoint `POST /api/bookings/saga`.
+
+---
+
+## 15. Provjera baze podataka
+
+### Booking DB
+
+```bash
+# Spoji se na MySQL Booking DB
+mysql -h 127.0.0.1 -P 3309 -u sportcenter -p sportcenter_booking_db
+# Password: sportcenter123
+```
+
+```sql
+-- Provjeri sve bookinge sa statusima
+SELECT id, user_id, facility_id, status, created_at 
+FROM booking 
+ORDER BY id DESC 
+LIMIT 10;
+
+-- Sretni put: status = CONFIRMED
+-- Kompenzacija: status = CANCELLED
+-- U toku: status = PENDING
+```
+
+### Payment DB
+
+```bash
+mysql -h 127.0.0.1 -P 3310 -u sportcenter -p sportcenter_payment_db
+```
+
+```sql
+-- Provjeri plaćanja kreirana sagom
+SELECT id, booking_id, amount, status, transaction_id, paid_at
+FROM payment
+WHERE transaction_id LIKE 'TXN-SAGA-%'
+ORDER BY id DESC;
+
+-- Sretni put: status = PAID, paid_at != NULL
+-- Kompenzacija: status = FAILED
+```
+
+---
+
+## 16. Česta pitanja na odbrani
+
+### P: Zašto Saga Choreography a ne Orchestration?
+
+**O:** Choreography je bolja za naš slučaj jer:
+1. Nema centralnog orkestratora koji može biti single point of failure
+2. Svaki servis je nezavisan — Booking Service ne mora znati o Payment Service implementaciji
+3. Lakše dodati novi korak u sagu (npr. notifikacija) bez promjene postojećeg koda — samo dodamo novi listener
+
+### P: Šta je sagaId i zašto je koristan?
+
+**O:** SagaId je UUID koji se generiše pri pokretanju sage i prenosi kroz sve evente. Koristi se za:
+- **Logging:** Svi eventi iste sage imaju isti `[SAGA][sagaId]` prefix → lako pratiti cijeli tok
+- **Debugging:** U centralizovanim logovima filtriramo po sagaId i vidimo sve korake
+- **Idempotentnost:** Mogu se detektovati duplirani eventi (po sagaId + bookingId)
+
+### P: Šta ako RabbitMQ padne dok je poruka u queuu?
+
+**O:** Koristimo `durable=true` na exchange i queues. Ovo znači da RabbitMQ sprema poruke na disk i ne gubi ih pri restartu. Poruke koje su primljene u queue ali nisu consumovane ostaju dok servis ne pročita i potvrdi (ACK). Spring AMQP automatski šalje ACK nakon uspješne obrade.
+
+### P: Šta ako Booking Service padne između slanja eventa i primanja PaymentCompleted?
+
+**O:** RabbitMQ zadržava poruku. Kada Booking Service ponovo stane, odmah će primiti poruku iz queuea i obraditi je. Zbog idempotentnosti (provjera da li je booking već CONFIRMED/CANCELLED), duplirana obrada neće napraviti problem.
+
+### P: Zašto je HTTP odgovor 202 a ne 200?
+
+**O:** HTTP 202 Accepted semantički znači "zahtjev je prihvaćen ali nije još obrađen". Pošto booking akcija nije finalna (CONFIRMED/CANCELLED) u trenutku HTTP odgovora, 202 je ispravna šifra. 200 OK znači "akcija je završena", što nije tačno u asinkronom modelu.
+
+### P: Kako se razlikuju saga eventi od regularnih paymenta?
+
+**O:** Saga paymenti imaju `transactionId` koji počinje sa `TXN-SAGA-`, dok regularni paymenti imaju `TXN-`. Ovo olakšava razlikovanje u bazi i u logovima.
+
+### P: Koji test pokriva kompenzacijsku transakciju?
+
+**O:** Primarno:
+- `BookingSagaServiceTest.cancelBooking_compensatingTransaction_updatesStatusToCancelled` — direktno testira inverznu akciju
+- `PaymentSagaServiceTest.processPayment_withSimulateFailure_savesPaymentAsFailed_andPublishesFailedEvent` — testira okidanje kompenzacije iz Payment Servicea
+
+### P: Kako se osigurava da se booking ne potvrdi ako payment padne?
+
+**O:** Booking ostaje u statusu PENDING sve dok ne primi jedan od dva eventa:
+- `PaymentCompletedEvent` → CONFIRMED
+- `PaymentFailedEvent` → CANCELLED
+
+Ne postoji timeout — booking može ostati PENDING ako event nikada ne stigne. U produkcijskom sistemu dodali bismo job koji nakon određenog vremena otkazuje PENDING bookinge (Dead Letter Queue + TTL mehanizam).
+
+### P: Razlika između ovog pristupa i Z5 (synchronous orchestration)?
+
+| Aspekt | Z5 Sinkrono (Feign) | Z7 Asinkrono (RabbitMQ) |
+|---|---|---|
+| HTTP odgovor | 201 Created | 202 Accepted |
+| Booking status odmah | CONFIRMED ili CANCELLED | PENDING |
+| Blokira klijenta | Da, dok sve ne završi | Ne |
+| Mreža dostupna | Mora biti | Nije potrebna odmah |
+| Pattern | Orchestration | Choreography |
+| Transakcija | Pokušaj atomičnosti | Saga (lokalne TX + kompenzacija) |
+
+---
+
+## Sažetak — Ispunjenost zahtjeva zadatka
+
+| Zahtjev zadatka | Implementacija |
+|---|---|
+| "asinkronu komunikaciju koristeći RabbitMQ" | ✅ Topic Exchange + 3 durable queues, Jackson JSON serijalizacija |
+| "event-based pristup/saga choreography" | ✅ 3 eventi, nema centralnog orkestratora, svaki servis nezavisan |
+| "bar dva upisa u bazu u različitim mikroservisima" | ✅ TX1: `booking_db.booking` u Booking Serviceu; TX2: `payment_db.payment` u Payment Serviceu |
+| "bar dvije lokalne transakcije" | ✅ `@Transactional` na `initiate()` i `processPayment()` |
+| "obje trebaju zavisiti jedna od druge" | ✅ TX2 koristi `bookingId` iz TX1; konačni status TX1 ovisi o ishodu TX2 |
+| "ako jedna padne i druga poziva inverznu akciju" | ✅ `PaymentFailedEvent` → `cancelBooking()` → `Booking.CANCELLED` |
+| "obrnuto" (TX1 pad → TX2 kompenzacija) | ✅ Ako TX1 padne (DB greška), event se ne šalje → TX2 se nikada ne pokrene |
+| "označiti akciju da je finalna" | ✅ `Booking.status = CONFIRMED` + log "saga COMPLETE" |
+| "komunikaciju dokumentovati sa dijagramom" | ✅ ASCII dijagrami u ovom dokumentu + `IZVJESTAJ_Z7.md` |
+| Testovi | ✅ 15 unit testova koji pokrivaju sve putanje (happy + kompenzacijska) |

--- a/Payment Service/pom.xml
+++ b/Payment Service/pom.xml
@@ -106,6 +106,15 @@
             <artifactId>json-patch</artifactId>
             <version>1.13</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-amqp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.amqp</groupId>
+            <artifactId>spring-rabbit-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/Payment Service/src/main/java/ba/nwt/paymentservice/config/RabbitMQConfig.java
+++ b/Payment Service/src/main/java/ba/nwt/paymentservice/config/RabbitMQConfig.java
@@ -1,0 +1,79 @@
+package ba.nwt.paymentservice.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.amqp.core.*;
+import org.springframework.amqp.support.converter.Jackson2JavaTypeMapper;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfig {
+
+    // ── Exchange ──────────────────────────────────────────────────────────────
+    public static final String SAGA_EXCHANGE = "sportcenter.saga.exchange";
+
+    // ── Queue names ───────────────────────────────────────────────────────────
+    public static final String BOOKING_CREATED_QUEUE   = "sportcenter.booking.created.queue";
+    public static final String PAYMENT_COMPLETED_QUEUE = "sportcenter.payment.completed.queue";
+    public static final String PAYMENT_FAILED_QUEUE    = "sportcenter.payment.failed.queue";
+
+    // ── Routing keys ──────────────────────────────────────────────────────────
+    public static final String BOOKING_CREATED_KEY   = "booking.saga.created";
+    public static final String PAYMENT_COMPLETED_KEY = "payment.saga.completed";
+    public static final String PAYMENT_FAILED_KEY    = "payment.saga.failed";
+
+    @Bean
+    public TopicExchange sagaExchange() {
+        return ExchangeBuilder.topicExchange(SAGA_EXCHANGE).durable(true).build();
+    }
+
+    // ── Queues declared by Payment Service (the one it consumes) ─────────────
+    @Bean
+    public Queue bookingCreatedQueue() {
+        return QueueBuilder.durable(BOOKING_CREATED_QUEUE).build();
+    }
+
+    // Also declare queues that Booking Service consumes to ensure they exist.
+    @Bean
+    public Queue paymentCompletedQueue() {
+        return QueueBuilder.durable(PAYMENT_COMPLETED_QUEUE).build();
+    }
+
+    @Bean
+    public Queue paymentFailedQueue() {
+        return QueueBuilder.durable(PAYMENT_FAILED_QUEUE).build();
+    }
+
+    // ── Bindings ──────────────────────────────────────────────────────────────
+    @Bean
+    public Binding bookingCreatedBinding() {
+        return BindingBuilder.bind(bookingCreatedQueue())
+                .to(sagaExchange()).with(BOOKING_CREATED_KEY);
+    }
+
+    @Bean
+    public Binding paymentCompletedBinding() {
+        return BindingBuilder.bind(paymentCompletedQueue())
+                .to(sagaExchange()).with(PAYMENT_COMPLETED_KEY);
+    }
+
+    @Bean
+    public Binding paymentFailedBinding() {
+        return BindingBuilder.bind(paymentFailedQueue())
+                .to(sagaExchange()).with(PAYMENT_FAILED_KEY);
+    }
+
+    // ── JSON message converter ─────────────────────────────────────────────────
+    // Inject Spring Boot's ObjectMapper (has JavaTimeModule → LocalDateTime works).
+    // INFERRED type precedence: use @RabbitListener method's parameter type for
+    // deserialization instead of the __TypeId__ header, which would contain the
+    // sender's package name (not present in this service's classpath).
+    @Bean
+    public MessageConverter jsonMessageConverter(ObjectMapper objectMapper) {
+        Jackson2JsonMessageConverter converter = new Jackson2JsonMessageConverter(objectMapper);
+        converter.setTypePrecedence(Jackson2JavaTypeMapper.TypePrecedence.INFERRED);
+        return converter;
+    }
+}

--- a/Payment Service/src/main/java/ba/nwt/paymentservice/saga/PaymentSagaConsumer.java
+++ b/Payment Service/src/main/java/ba/nwt/paymentservice/saga/PaymentSagaConsumer.java
@@ -1,0 +1,30 @@
+package ba.nwt.paymentservice.saga;
+
+import ba.nwt.paymentservice.config.RabbitMQConfig;
+import ba.nwt.paymentservice.saga.event.BookingCreatedEvent;
+import ba.nwt.paymentservice.service.PaymentSagaService;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentSagaConsumer {
+
+    private static final Logger log = LoggerFactory.getLogger(PaymentSagaConsumer.class);
+
+    private final PaymentSagaService paymentSagaService;
+
+    /**
+     * Receives BookingCreatedEvent from Booking Service.
+     * Executes local transaction 2: create and process the payment.
+     */
+    @RabbitListener(queues = RabbitMQConfig.BOOKING_CREATED_QUEUE)
+    public void onBookingCreated(BookingCreatedEvent event) {
+        log.info("[SAGA][{}] Received BookingCreatedEvent for bookingId={} amount={}",
+                event.getSagaId(), event.getBookingId(), event.getTotalPrice());
+        paymentSagaService.processPayment(event);
+    }
+}

--- a/Payment Service/src/main/java/ba/nwt/paymentservice/saga/PaymentSagaPublisher.java
+++ b/Payment Service/src/main/java/ba/nwt/paymentservice/saga/PaymentSagaPublisher.java
@@ -1,0 +1,39 @@
+package ba.nwt.paymentservice.saga;
+
+import ba.nwt.paymentservice.config.RabbitMQConfig;
+import ba.nwt.paymentservice.saga.event.PaymentCompletedEvent;
+import ba.nwt.paymentservice.saga.event.PaymentFailedEvent;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentSagaPublisher {
+
+    private static final Logger log = LoggerFactory.getLogger(PaymentSagaPublisher.class);
+
+    private final RabbitTemplate rabbitTemplate;
+
+    public void publishPaymentCompleted(PaymentCompletedEvent event) {
+        log.info("[SAGA][{}] Publishing PaymentCompletedEvent for bookingId={} paymentId={}",
+                event.getSagaId(), event.getBookingId(), event.getPaymentId());
+        rabbitTemplate.convertAndSend(
+                RabbitMQConfig.SAGA_EXCHANGE,
+                RabbitMQConfig.PAYMENT_COMPLETED_KEY,
+                event
+        );
+    }
+
+    public void publishPaymentFailed(PaymentFailedEvent event) {
+        log.warn("[SAGA][{}] Publishing PaymentFailedEvent for bookingId={} reason={}",
+                event.getSagaId(), event.getBookingId(), event.getReason());
+        rabbitTemplate.convertAndSend(
+                RabbitMQConfig.SAGA_EXCHANGE,
+                RabbitMQConfig.PAYMENT_FAILED_KEY,
+                event
+        );
+    }
+}

--- a/Payment Service/src/main/java/ba/nwt/paymentservice/saga/event/BookingCreatedEvent.java
+++ b/Payment Service/src/main/java/ba/nwt/paymentservice/saga/event/BookingCreatedEvent.java
@@ -1,0 +1,36 @@
+package ba.nwt.paymentservice.saga.event;
+
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * Received by Payment Service from Booking Service when a booking is saved as PENDING.
+ * Triggers local transaction 2: create and process the payment.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BookingCreatedEvent {
+
+    private String sagaId;
+
+    private Long bookingId;
+    private Long userId;
+    private Long facilityId;
+
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+
+    private BigDecimal totalPrice;
+
+    /** CREDIT_CARD | DEBIT_CARD | PAYPAL */
+    private String paymentMethod;
+
+    private LocalDateTime timestamp;
+
+    /** When true, this service will simulate a payment failure (for testing compensating transactions). */
+    private boolean simulateFailure;
+}

--- a/Payment Service/src/main/java/ba/nwt/paymentservice/saga/event/PaymentCompletedEvent.java
+++ b/Payment Service/src/main/java/ba/nwt/paymentservice/saga/event/PaymentCompletedEvent.java
@@ -1,0 +1,27 @@
+package ba.nwt.paymentservice.saga.event;
+
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * Published by Payment Service when payment succeeds.
+ * Consumed by Booking Service to update booking status to CONFIRMED (final state).
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PaymentCompletedEvent {
+
+    private String sagaId;
+
+    private Long bookingId;
+    private Long paymentId;
+
+    private String transactionId;
+    private BigDecimal amount;
+
+    private LocalDateTime timestamp;
+}

--- a/Payment Service/src/main/java/ba/nwt/paymentservice/saga/event/PaymentFailedEvent.java
+++ b/Payment Service/src/main/java/ba/nwt/paymentservice/saga/event/PaymentFailedEvent.java
@@ -1,0 +1,25 @@
+package ba.nwt.paymentservice.saga.event;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+/**
+ * Published by Payment Service when payment processing fails.
+ * Consumed by Booking Service to execute the compensating action (cancel the booking).
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PaymentFailedEvent {
+
+    private String sagaId;
+
+    private Long bookingId;
+
+    /** Human-readable failure reason. */
+    private String reason;
+
+    private LocalDateTime timestamp;
+}

--- a/Payment Service/src/main/java/ba/nwt/paymentservice/service/PaymentSagaService.java
+++ b/Payment Service/src/main/java/ba/nwt/paymentservice/service/PaymentSagaService.java
@@ -1,0 +1,111 @@
+package ba.nwt.paymentservice.service;
+
+import ba.nwt.paymentservice.model.Payment;
+import ba.nwt.paymentservice.repository.PaymentRepository;
+import ba.nwt.paymentservice.saga.PaymentSagaPublisher;
+import ba.nwt.paymentservice.saga.event.BookingCreatedEvent;
+import ba.nwt.paymentservice.saga.event.PaymentCompletedEvent;
+import ba.nwt.paymentservice.saga.event.PaymentFailedEvent;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Orchestrates the Payment side of the Booking-Payment Saga.
+ *
+ * Saga steps owned by this service:
+ *  1. processPayment() — save Payment(PENDING), attempt charge, update to PAID or FAILED
+ *                        [local transaction 2]
+ *     → On success: publish PaymentCompletedEvent
+ *     → On failure: publish PaymentFailedEvent  (triggers compensating tx in Booking Service)
+ */
+@Service
+@RequiredArgsConstructor
+public class PaymentSagaService {
+
+    private static final Logger log = LoggerFactory.getLogger(PaymentSagaService.class);
+
+    private final PaymentRepository paymentRepository;
+    private final PaymentSagaPublisher publisher;
+
+    /**
+     * Local Transaction 2: create payment record and attempt processing.
+     *
+     * If simulateFailure=true, the payment is immediately marked FAILED
+     * (used to test the compensating transaction path in Booking Service).
+     */
+    @Transactional
+    public void processPayment(BookingCreatedEvent event) {
+        log.info("[SAGA][{}] Local txn 2 start — processing payment for bookingId={}",
+                event.getSagaId(), event.getBookingId());
+
+        Payment.PaymentMethod method;
+        try {
+            method = Payment.PaymentMethod.valueOf(event.getPaymentMethod());
+        } catch (IllegalArgumentException e) {
+            method = Payment.PaymentMethod.CREDIT_CARD;
+        }
+
+        // ── Save Payment PENDING ───────────────────────────────────────────────
+        Payment payment = paymentRepository.save(Payment.builder()
+                .bookingId(event.getBookingId())
+                .amount(event.getTotalPrice())
+                .depositAmount(java.math.BigDecimal.ZERO)
+                .paymentMethod(method)
+                .transactionId("TXN-SAGA-" + UUID.randomUUID().toString().substring(0, 8).toUpperCase())
+                .status(Payment.PaymentStatus.PENDING)
+                .build());
+
+        log.info("[SAGA][{}] Payment saved id={} status=PENDING transactionId={}",
+                event.getSagaId(), payment.getId(), payment.getTransactionId());
+
+        // ── Simulate failure path (for testing) ───────────────────────────────
+        if (event.isSimulateFailure()) {
+            payment.setStatus(Payment.PaymentStatus.FAILED);
+            paymentRepository.save(payment);
+            log.warn("[SAGA][{}] Payment id={} FAILED (simulated) — publishing PaymentFailedEvent",
+                    event.getSagaId(), payment.getId());
+            publisher.publishPaymentFailed(PaymentFailedEvent.builder()
+                    .sagaId(event.getSagaId())
+                    .bookingId(event.getBookingId())
+                    .reason("Simulated payment failure for bookingId=" + event.getBookingId())
+                    .timestamp(LocalDateTime.now())
+                    .build());
+            return;
+        }
+
+        // ── Happy path: mark payment as PAID ──────────────────────────────────
+        try {
+            payment.setStatus(Payment.PaymentStatus.PAID);
+            payment.setPaidAt(LocalDateTime.now());
+            Payment saved = paymentRepository.save(payment);
+            log.info("[SAGA][{}] Payment id={} PAID — publishing PaymentCompletedEvent",
+                    event.getSagaId(), saved.getId());
+            publisher.publishPaymentCompleted(PaymentCompletedEvent.builder()
+                    .sagaId(event.getSagaId())
+                    .bookingId(event.getBookingId())
+                    .paymentId(saved.getId())
+                    .transactionId(saved.getTransactionId())
+                    .amount(saved.getAmount())
+                    .timestamp(LocalDateTime.now())
+                    .build());
+        } catch (Exception ex) {
+            // Unexpected error during payment processing — compensate
+            payment.setStatus(Payment.PaymentStatus.FAILED);
+            paymentRepository.save(payment);
+            log.error("[SAGA][{}] Unexpected error during payment processing: {}",
+                    event.getSagaId(), ex.getMessage());
+            publisher.publishPaymentFailed(PaymentFailedEvent.builder()
+                    .sagaId(event.getSagaId())
+                    .bookingId(event.getBookingId())
+                    .reason("Internal payment error: " + ex.getMessage())
+                    .timestamp(LocalDateTime.now())
+                    .build());
+        }
+    }
+}

--- a/Payment Service/src/main/resources/application.properties
+++ b/Payment Service/src/main/resources/application.properties
@@ -26,3 +26,10 @@ management.endpoint.health.show-details=always
 
 springdoc.api-docs.path=/api-docs
 springdoc.swagger-ui.path=/swagger-ui.html
+
+# ── RabbitMQ ──────────────────────────────────────────────────────────────────
+spring.rabbitmq.host=${RABBITMQ_HOST:localhost}
+spring.rabbitmq.port=${RABBITMQ_PORT:5672}
+spring.rabbitmq.username=${RABBITMQ_USER:guest}
+spring.rabbitmq.password=${RABBITMQ_PASS:guest}
+spring.rabbitmq.virtual-host=/

--- a/Payment Service/src/test/java/ba/nwt/paymentservice/PaymentServiceApplicationTests.java
+++ b/Payment Service/src/test/java/ba/nwt/paymentservice/PaymentServiceApplicationTests.java
@@ -8,6 +8,10 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 class PaymentServiceApplicationTests {
 
+    /** Mock RabbitTemplate so the context loads without a real RabbitMQ broker. */
+    @org.springframework.boot.test.mock.mockito.MockBean
+    private org.springframework.amqp.rabbit.core.RabbitTemplate rabbitTemplate;
+
     @Test
     void contextLoads() {
     }

--- a/Payment Service/src/test/java/ba/nwt/paymentservice/saga/PaymentSagaServiceTest.java
+++ b/Payment Service/src/test/java/ba/nwt/paymentservice/saga/PaymentSagaServiceTest.java
@@ -1,0 +1,213 @@
+package ba.nwt.paymentservice.saga;
+
+import ba.nwt.paymentservice.model.Payment;
+import ba.nwt.paymentservice.repository.PaymentRepository;
+import ba.nwt.paymentservice.saga.event.BookingCreatedEvent;
+import ba.nwt.paymentservice.saga.event.PaymentCompletedEvent;
+import ba.nwt.paymentservice.saga.event.PaymentFailedEvent;
+import ba.nwt.paymentservice.service.PaymentSagaService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for PaymentSagaService — the Payment Service's side of the Saga.
+ *
+ * Tests cover:
+ *  1. processPayment() happy path → saves Payment(PAID), publishes PaymentCompletedEvent
+ *  2. processPayment() failure path → saves Payment(FAILED), publishes PaymentFailedEvent
+ *  3. Correct transactionId format
+ *  4. Correct paymentMethod mapping
+ */
+@ExtendWith(MockitoExtension.class)
+class PaymentSagaServiceTest {
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @Mock
+    private PaymentSagaPublisher publisher;
+
+    @InjectMocks
+    private PaymentSagaService paymentSagaService;
+
+    private BookingCreatedEvent baseEvent;
+
+    @BeforeEach
+    void setUp() {
+        baseEvent = BookingCreatedEvent.builder()
+                .sagaId("saga-test-001")
+                .bookingId(5L)
+                .userId(1L)
+                .facilityId(2L)
+                .startTime(LocalDateTime.now().plusDays(1))
+                .endTime(LocalDateTime.now().plusDays(1).plusHours(2))
+                .totalPrice(new BigDecimal("100.00"))
+                .paymentMethod("CREDIT_CARD")
+                .simulateFailure(false)
+                .timestamp(LocalDateTime.now())
+                .build();
+    }
+
+    // ── Happy path ────────────────────────────────────────────────────────────
+
+    @Test
+    void processPayment_happyPath_savesPaymentAsPaid_andPublishesCompletedEvent() {
+        Payment pendingPayment = Payment.builder()
+                .id(99L)
+                .bookingId(5L)
+                .amount(new BigDecimal("100.00"))
+                .status(Payment.PaymentStatus.PENDING)
+                .transactionId("TXN-SAGA-ABC123")
+                .build();
+
+        // First save (PENDING), second save (PAID)
+        when(paymentRepository.save(any(Payment.class)))
+                .thenReturn(pendingPayment)   // first call
+                .thenReturn(Payment.builder() // second call
+                        .id(99L)
+                        .bookingId(5L)
+                        .amount(new BigDecimal("100.00"))
+                        .status(Payment.PaymentStatus.PAID)
+                        .transactionId("TXN-SAGA-ABC123")
+                        .paidAt(LocalDateTime.now())
+                        .build());
+
+        paymentSagaService.processPayment(baseEvent);
+
+        // Verify two saves: PENDING then PAID
+        ArgumentCaptor<Payment> captor = ArgumentCaptor.forClass(Payment.class);
+        verify(paymentRepository, times(2)).save(captor.capture());
+
+        assertThat(captor.getAllValues().get(0).getStatus()).isEqualTo(Payment.PaymentStatus.PENDING);
+        assertThat(captor.getAllValues().get(1).getStatus()).isEqualTo(Payment.PaymentStatus.PAID);
+
+        // Verify PaymentCompletedEvent published
+        verify(publisher).publishPaymentCompleted(argThat(event ->
+                event.getSagaId().equals("saga-test-001")
+                && event.getBookingId().equals(5L)
+                && event.getPaymentId().equals(99L)
+        ));
+        verify(publisher, never()).publishPaymentFailed(any());
+    }
+
+    @Test
+    void processPayment_happyPath_transactionIdHasSagaPrefix() {
+        when(paymentRepository.save(any())).thenAnswer(inv -> {
+            Payment p = inv.getArgument(0);
+            p.setId(1L);
+            return p;
+        });
+
+        paymentSagaService.processPayment(baseEvent);
+
+        ArgumentCaptor<Payment> captor = ArgumentCaptor.forClass(Payment.class);
+        verify(paymentRepository, atLeastOnce()).save(captor.capture());
+
+        String txnId = captor.getAllValues().get(0).getTransactionId();
+        assertThat(txnId).startsWith("TXN-SAGA-");
+    }
+
+    // ── Failure / compensating path ───────────────────────────────────────────
+
+    @Test
+    void processPayment_withSimulateFailure_savesPaymentAsFailed_andPublishesFailedEvent() {
+        BookingCreatedEvent failEvent = BookingCreatedEvent.builder()
+                .sagaId("saga-fail-001")
+                .bookingId(7L)
+                .totalPrice(new BigDecimal("200.00"))
+                .paymentMethod("DEBIT_CARD")
+                .simulateFailure(true)
+                .timestamp(LocalDateTime.now())
+                .build();
+
+        Payment pendingPayment = Payment.builder()
+                .id(55L)
+                .bookingId(7L)
+                .status(Payment.PaymentStatus.PENDING)
+                .build();
+
+        when(paymentRepository.save(any(Payment.class)))
+                .thenReturn(pendingPayment)
+                .thenReturn(Payment.builder().id(55L).status(Payment.PaymentStatus.FAILED).build());
+
+        paymentSagaService.processPayment(failEvent);
+
+        // Verify two saves: PENDING then FAILED
+        ArgumentCaptor<Payment> captor = ArgumentCaptor.forClass(Payment.class);
+        verify(paymentRepository, times(2)).save(captor.capture());
+
+        assertThat(captor.getAllValues().get(0).getStatus()).isEqualTo(Payment.PaymentStatus.PENDING);
+        assertThat(captor.getAllValues().get(1).getStatus()).isEqualTo(Payment.PaymentStatus.FAILED);
+
+        // Verify PaymentFailedEvent published (compensating trigger)
+        verify(publisher).publishPaymentFailed(argThat(event ->
+                event.getSagaId().equals("saga-fail-001")
+                && event.getBookingId().equals(7L)
+                && event.getReason() != null
+        ));
+        verify(publisher, never()).publishPaymentCompleted(any());
+    }
+
+    @Test
+    void processPayment_onUnexpectedException_publishesPaymentFailedEvent() {
+        Payment pendingPayment = Payment.builder()
+                .id(88L)
+                .bookingId(5L)
+                .status(Payment.PaymentStatus.PENDING)
+                .transactionId("TXN-SAGA-ERR")
+                .build();
+
+        when(paymentRepository.save(any(Payment.class)))
+                .thenReturn(pendingPayment)
+                // Second save (PAID attempt) throws
+                .thenThrow(new RuntimeException("DB connection lost"))
+                // Third save (FAILED)
+                .thenReturn(Payment.builder().id(88L).status(Payment.PaymentStatus.FAILED).build());
+
+        paymentSagaService.processPayment(baseEvent);
+
+        verify(publisher).publishPaymentFailed(argThat(event ->
+                event.getReason().contains("DB connection lost")
+        ));
+        verify(publisher, never()).publishPaymentCompleted(any());
+    }
+
+    // ── PaymentMethod mapping ─────────────────────────────────────────────────
+
+    @Test
+    void processPayment_unknownPaymentMethod_defaultsToCreditCard() {
+        BookingCreatedEvent event = BookingCreatedEvent.builder()
+                .sagaId("saga-method")
+                .bookingId(3L)
+                .totalPrice(BigDecimal.TEN)
+                .paymentMethod("BITCOIN") // unknown
+                .simulateFailure(false)
+                .timestamp(LocalDateTime.now())
+                .build();
+
+        when(paymentRepository.save(any())).thenAnswer(inv -> {
+            Payment p = inv.getArgument(0);
+            p.setId(1L);
+            return p;
+        });
+
+        paymentSagaService.processPayment(event);
+
+        ArgumentCaptor<Payment> captor = ArgumentCaptor.forClass(Payment.class);
+        verify(paymentRepository, atLeastOnce()).save(captor.capture());
+        assertThat(captor.getAllValues().get(0).getPaymentMethod())
+                .isEqualTo(Payment.PaymentMethod.CREDIT_CARD);
+    }
+}

--- a/Payment Service/src/test/resources/application-test.properties
+++ b/Payment Service/src/test/resources/application-test.properties
@@ -13,4 +13,5 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
 
 spring.main.allow-bean-definition-overriding=true
 
-
+# ── Z7 — Disable RabbitMQ auto-connect in unit/slice tests ───────────────────
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration

--- a/README.md
+++ b/README.md
@@ -270,12 +270,15 @@ Test korisnici se kreiraju automatski pri startu: `john_doe`, `admin`, `vlasnik_
 ## Korisne Docker komande
 
 ```bash
-docker compose ps          # Status kontejnera
-docker compose logs -f     # Pratiti logove svih baza
-docker compose down        # Zaustavi kontejnere (podaci ostaju u volumeima)
-docker compose down -v     # Zaustavi i OBRIŠI sve podatke (fresh start)
-docker compose up -d       # Ponovo pokreni
+docker compose ps             # Status kontejnera (MySQL x4 + RabbitMQ)
+docker compose logs -f        # Pratiti logove svih servisa
+docker compose down           # Zaustavi kontejnere (podaci ostaju u volumeima)
+docker compose down -v        # Zaustavi i OBRIŠI sve podatke (fresh start)
+docker compose up -d          # Ponovo pokreni sve (MySQL + RabbitMQ)
+docker compose up rabbitmq -d # Pokreni samo RabbitMQ
 ```
+
+**RabbitMQ Management UI:** http://localhost:15672 (guest / guest)
 
 ---
 
@@ -384,14 +387,57 @@ Svaki servis automatski unosi testne podatke pri prvom startu:
 
 ---
 
+## Z7 — Asinhrona komunikacija (RabbitMQ Saga Choreography)
+
+### Brzi start
+
+```bash
+# 1. Pokrenuti RabbitMQ (dodan u docker-compose.yml)
+docker compose up rabbitmq -d
+
+# 2. Provjera — Management UI
+# http://localhost:15672  (guest / guest)
+```
+
+### Saga endpoint
+
+```bash
+# Sretni put — booking se potvrdi asinkrono
+POST http://localhost:8083/api/bookings/saga
+
+# Kompenzacijska transakcija — booking se otkaže ako payment padne
+POST http://localhost:8083/api/bookings/saga?simulateFailure=true
+```
+
+### Tok sage
+
+```
+POST /saga → Booking(PENDING) → BookingCreatedEvent → RabbitMQ
+                                                            ↓
+                                           Payment Service: Payment(PENDING→PAID)
+                                                            ↓
+                                        PaymentCompletedEvent → Booking(CONFIRMED) ← FINALNO
+
+Ako payment padne:  PaymentFailedEvent → Booking(CANCELLED) ← KOMPENZACIJA
+```
+
+### Detaljna dokumentacija
+
+- **`IZVJESTAJ_Z8_DETALJAN.md`** — Kompletan izvještaj sa svim objašnjenjima, dijagramima i uputama za testiranje
+- **`IZVJESTAJ_Z8.md`** — Sažetak implementacije
+
+---
+
 ## Tech Stack
 
 - **Spring Boot 3.2.5**
 - **Java 17**
 - **MySQL 8.0** (Docker)
+- **RabbitMQ 3.13** (Docker, AMQP 5672, Management UI 15672)
 - **Spring Cloud Gateway** (API Gateway, JWT validacija, RBAC routing)
 - **Spring Security** (JWT authentication, BCrypt password hashing)
 - **Hibernate / JPA** (ORM)
+- **Spring AMQP** (RabbitMQ klijent, Saga Choreography)
 - **Lombok** (boilerplate redukcija)
 - **Maven Wrapper** (`./mvnw`)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,11 +84,32 @@ services:
       timeout: 5s
       retries: 5
 
+  # ── RabbitMQ Message Broker ────────────────────────────────────────────────
+  rabbitmq:
+    image: rabbitmq:3.13-management
+    container_name: sportcenter-rabbitmq
+    environment:
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_USER:-guest}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASS:-guest}
+    ports:
+      - "${RABBITMQ_PORT:-5672}:5672"       # AMQP protocol
+      - "${RABBITMQ_MGMT_PORT:-15672}:15672" # Management UI
+    volumes:
+      - rabbitmq-data:/var/lib/rabbitmq
+    networks:
+      - sportcenter-net
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "ping"]
+      interval: 15s
+      timeout: 10s
+      retries: 5
+
 volumes:
   user-db-data:
   resource-db-data:
   booking-db-data:
   payment-db-data:
+  rabbitmq-data:
 
 networks:
   sportcenter-net:


### PR DESCRIPTION
  Implements asynchronous inter-service communication between Booking Service and Payment Service using the Saga Choreography pattern over RabbitMQ.

  What changed:
  - New endpoint POST /api/bookings/saga returns 202 Accepted immediately; final status arrives asynchronously
  - Booking Service writes Booking(PENDING) as local transaction 1, publishes BookingCreatedEvent
  - Payment Service consumes the event, writes Payment(PENDING → PAID) as local transaction 2, publishes PaymentCompletedEvent
  - On success: Booking Service confirms the booking (CONFIRMED) — final state
  - On failure: Payment Service publishes PaymentFailedEvent → Booking Service cancels the booking (CANCELLED) — compensating/inverse action

  Infrastructure:
  - RabbitMQ 3.13 added to docker-compose.yml (AMQP :5672, Management UI :15672)
  - Topic exchange sportcenter.saga.exchange with 3 durable queues

  Tests: 15 new unit tests covering happy path, compensating transaction, idempotency, and error handling.