### PR TITLE
chore(*): Add integration tests for all microservices

### DIFF
--- a/Booking Service/src/test/java/ba/nwt/bookingservice/integration/BookingConflictFlowIT.java
+++ b/Booking Service/src/test/java/ba/nwt/bookingservice/integration/BookingConflictFlowIT.java
@@ -1,0 +1,156 @@
+package ba.nwt.bookingservice.integration;
+
+import ba.nwt.bookingservice.dto.BookingRequestDTO;
+import ba.nwt.bookingservice.dto.BookingResponseDTO;
+import ba.nwt.bookingservice.model.Booking;
+import ba.nwt.bookingservice.repository.BookingRepository;
+import ba.nwt.bookingservice.repository.BookingUserRepository;
+import ba.nwt.bookingservice.repository.EquipmentRentalRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Flow: conflict detection između rezervacija.
+ * Testira da conflict query ispravno detektuje preklapanja i ignoruje otkazane rezervacije.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class BookingConflictFlowIT {
+
+    @MockBean
+    private RabbitTemplate rabbitTemplate;
+
+    @Autowired private TestRestTemplate restTemplate;
+    @Autowired private BookingRepository bookingRepository;
+    @Autowired private BookingUserRepository bookingUserRepository;
+    @Autowired private EquipmentRentalRepository equipmentRentalRepository;
+
+    private static final Long FACILITY_A = 10L;
+    private static final Long FACILITY_B = 20L;
+
+    @BeforeEach
+    void cleanUp() {
+        bookingUserRepository.deleteAll();
+        equipmentRentalRepository.deleteAll();
+        bookingRepository.deleteAll();
+    }
+
+    private BookingResponseDTO createBooking(Long facilityId, LocalDateTime start, LocalDateTime end) {
+        return restTemplate.postForObject("/api/bookings",
+                BookingRequestDTO.builder()
+                        .userId(1L).facilityId(facilityId)
+                        .startTime(start).endTime(end)
+                        .totalPrice(new BigDecimal("100.00"))
+                        .status(Booking.BookingStatus.PENDING)
+                        .build(),
+                BookingResponseDTO.class);
+    }
+
+    private List<BookingResponseDTO> getConflicting(Long facilityId, LocalDateTime start, LocalDateTime end) {
+        String url = UriComponentsBuilder.fromPath("/api/bookings/facility/{fid}/conflicting")
+                .queryParam("start", start.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+                .queryParam("end", end.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+                .buildAndExpand(facilityId).toUriString();
+
+        ResponseEntity<List<BookingResponseDTO>> resp = restTemplate.exchange(
+                url, HttpMethod.GET, null,
+                new ParameterizedTypeReference<List<BookingResponseDTO>>() {});
+        return resp.getBody();
+    }
+
+    @Test
+    void twoOverlappingBookings_conflictEndpointDetectsBoth() {
+        LocalDateTime base = LocalDateTime.now().plusDays(7).withHour(10).withMinute(0).withSecond(0).withNano(0);
+
+        createBooking(FACILITY_A, base, base.plusHours(2));            // 10:00–12:00
+        createBooking(FACILITY_A, base.plusHours(1), base.plusHours(3)); // 11:00–13:00  ← preklapa
+
+        List<BookingResponseDTO> conflicts = getConflicting(FACILITY_A, base, base.plusHours(3));
+
+        assertThat(conflicts).hasSize(2);
+        assertThat(bookingRepository.count()).isEqualTo(2);
+    }
+
+    @Test
+    void cancellingOneBooking_removesItFromConflictResults() {
+        LocalDateTime base = LocalDateTime.now().plusDays(8).withHour(14).withMinute(0).withSecond(0).withNano(0);
+
+        BookingResponseDTO first  = createBooking(FACILITY_A, base, base.plusHours(2));
+        BookingResponseDTO second = createBooking(FACILITY_A, base.plusHours(1), base.plusHours(3));
+
+        // Cancel first booking — cancelled status is excluded from conflict query
+        BookingRequestDTO cancel = BookingRequestDTO.builder()
+                .userId(1L).facilityId(FACILITY_A)
+                .startTime(base).endTime(base.plusHours(2))
+                .totalPrice(new BigDecimal("100.00"))
+                .status(Booking.BookingStatus.CANCELLED)
+                .build();
+        restTemplate.exchange("/api/bookings/" + first.getId(),
+                HttpMethod.PUT, new HttpEntity<>(cancel), BookingResponseDTO.class);
+
+        List<BookingResponseDTO> conflicts = getConflicting(FACILITY_A, base, base.plusHours(3));
+
+        assertThat(conflicts).hasSize(1);
+        assertThat(conflicts.get(0).getId()).isEqualTo(second.getId());
+    }
+
+    @Test
+    void recurringCreation_shouldFailWithBadRequest_whenFirstOccurrenceConflicts() {
+        LocalDateTime base = LocalDateTime.now().plusDays(9).withHour(10).withMinute(0).withSecond(0).withNano(0);
+
+        // Zauzmi termin ručno (PENDING)
+        createBooking(FACILITY_A, base, base.plusHours(2));
+
+        // Pokušaj kreirati recurring za isti termin → conflict na prvoj iteraciji
+        String url = UriComponentsBuilder.fromPath("/api/bookings/recurring")
+                .queryParam("pattern", "WEEKLY").queryParam("occurrences", "3")
+                .toUriString();
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                url, HttpMethod.POST,
+                new HttpEntity<>(BookingRequestDTO.builder()
+                        .userId(1L).facilityId(FACILITY_A)
+                        .startTime(base).endTime(base.plusHours(2))
+                        .totalPrice(new BigDecimal("100.00")).build()),
+                String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        // Samo originalna rezervacija, nijedna recurring nije kreirana
+        assertThat(bookingRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    void bookingsOnDifferentFacilities_shouldNeverConflict() {
+        LocalDateTime base = LocalDateTime.now().plusDays(10).withHour(10).withMinute(0).withSecond(0).withNano(0);
+
+        createBooking(FACILITY_A, base, base.plusHours(2));
+        createBooking(FACILITY_B, base, base.plusHours(2)); // isti termin, drugi teren
+
+        List<BookingResponseDTO> conflictsA = getConflicting(FACILITY_A, base, base.plusHours(2));
+        List<BookingResponseDTO> conflictsB = getConflicting(FACILITY_B, base, base.plusHours(2));
+
+        assertThat(conflictsA).hasSize(1);
+        assertThat(conflictsB).hasSize(1);
+        assertThat(conflictsA.get(0).getFacilityId()).isEqualTo(FACILITY_A);
+        assertThat(conflictsB.get(0).getFacilityId()).isEqualTo(FACILITY_B);
+    }
+}

--- a/Booking Service/src/test/java/ba/nwt/bookingservice/integration/BookingCrudIT.java
+++ b/Booking Service/src/test/java/ba/nwt/bookingservice/integration/BookingCrudIT.java
@@ -1,0 +1,197 @@
+package ba.nwt.bookingservice.integration;
+
+import ba.nwt.bookingservice.dto.BookingRequestDTO;
+import ba.nwt.bookingservice.dto.BookingResponseDTO;
+import ba.nwt.bookingservice.model.Booking;
+import ba.nwt.bookingservice.repository.BookingRepository;
+import ba.nwt.bookingservice.repository.BookingUserRepository;
+import ba.nwt.bookingservice.repository.EquipmentRentalRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for Booking CRUD operations.
+ * POST /api/bookings is fully local (no Feign). Only /orchestrated uses Feign.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class BookingCrudIT {
+
+    @MockBean
+    private RabbitTemplate rabbitTemplate;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private BookingRepository bookingRepository;
+
+    @Autowired
+    private BookingUserRepository bookingUserRepository;
+
+    @Autowired
+    private EquipmentRentalRepository equipmentRentalRepository;
+
+    @BeforeEach
+    void cleanUp() {
+        bookingUserRepository.deleteAll();
+        equipmentRentalRepository.deleteAll();
+        bookingRepository.deleteAll();
+    }
+
+    private BookingRequestDTO buildRequest(Long userId, Long facilityId) {
+        LocalDateTime start = LocalDateTime.now().plusDays(1).withHour(10).withMinute(0).withSecond(0).withNano(0);
+        LocalDateTime end = start.plusHours(2);
+        return BookingRequestDTO.builder()
+                .userId(userId)
+                .facilityId(facilityId)
+                .startTime(start)
+                .endTime(end)
+                .totalPrice(new BigDecimal("100.00"))
+                .isRecurring(false)
+                .status(Booking.BookingStatus.PENDING)
+                .build();
+    }
+
+    @Test
+    void createBooking_shouldReturn201AndPersistToDatabase() {
+        BookingRequestDTO request = buildRequest(1L, 10L);
+
+        ResponseEntity<BookingResponseDTO> response =
+                restTemplate.postForEntity("/api/bookings", request, BookingResponseDTO.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getId()).isPositive();
+        assertThat(response.getBody().getUserId()).isEqualTo(1L);
+        assertThat(response.getBody().getFacilityId()).isEqualTo(10L);
+        assertThat(response.getBody().getStatus()).isEqualTo(Booking.BookingStatus.PENDING);
+        assertThat(response.getBody().getTotalPrice()).isEqualByComparingTo("100.00");
+        assertThat(bookingRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    void getBookingById_shouldReturn200WithPersistedData() {
+        BookingResponseDTO created =
+                restTemplate.postForObject("/api/bookings", buildRequest(2L, 20L), BookingResponseDTO.class);
+
+        ResponseEntity<BookingResponseDTO> response =
+                restTemplate.getForEntity("/api/bookings/" + created.getId(), BookingResponseDTO.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getUserId()).isEqualTo(2L);
+        assertThat(response.getBody().getFacilityId()).isEqualTo(20L);
+    }
+
+    @Test
+    void getBookingsByUserId_shouldReturnOnlyThatUsersBookings() {
+        restTemplate.postForObject("/api/bookings", buildRequest(5L, 10L), BookingResponseDTO.class);
+        restTemplate.postForObject("/api/bookings", buildRequest(5L, 11L), BookingResponseDTO.class);
+        restTemplate.postForObject("/api/bookings", buildRequest(9L, 10L), BookingResponseDTO.class);
+
+        ResponseEntity<List<BookingResponseDTO>> response = restTemplate.exchange(
+                "/api/bookings/user/5",
+                HttpMethod.GET, null,
+                new ParameterizedTypeReference<List<BookingResponseDTO>>() {});
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(2);
+        assertThat(response.getBody()).allMatch(b -> b.getUserId().equals(5L));
+    }
+
+    @Test
+    void getBookingsByStatus_shouldReturnOnlyMatchingStatus() {
+        restTemplate.postForObject("/api/bookings", buildRequest(1L, 10L), BookingResponseDTO.class);
+        restTemplate.postForObject("/api/bookings", buildRequest(2L, 10L), BookingResponseDTO.class);
+
+        // Directly update one booking to CONFIRMED via repository to test status filtering
+        bookingRepository.findAll().stream().limit(1).forEach(b -> {
+            b.setStatus(Booking.BookingStatus.CONFIRMED);
+            bookingRepository.save(b);
+        });
+
+        ResponseEntity<List<BookingResponseDTO>> response = restTemplate.exchange(
+                "/api/bookings/status/PENDING",
+                HttpMethod.GET, null,
+                new ParameterizedTypeReference<List<BookingResponseDTO>>() {});
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(1);
+        assertThat(response.getBody().get(0).getStatus()).isEqualTo(Booking.BookingStatus.PENDING);
+    }
+
+    @Test
+    void updateBooking_shouldReturn200WithModifiedData() {
+        BookingResponseDTO created =
+                restTemplate.postForObject("/api/bookings", buildRequest(1L, 10L), BookingResponseDTO.class);
+
+        LocalDateTime newStart = LocalDateTime.now().plusDays(3).withHour(14).withMinute(0).withSecond(0).withNano(0);
+        BookingRequestDTO updateRequest = BookingRequestDTO.builder()
+                .userId(1L)
+                .facilityId(10L)
+                .startTime(newStart)
+                .endTime(newStart.plusHours(1))
+                .totalPrice(new BigDecimal("75.00"))
+                .status(Booking.BookingStatus.CONFIRMED)
+                .build();
+
+        ResponseEntity<BookingResponseDTO> response = restTemplate.exchange(
+                "/api/bookings/" + created.getId(),
+                HttpMethod.PUT,
+                new HttpEntity<>(updateRequest),
+                BookingResponseDTO.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getStatus()).isEqualTo(Booking.BookingStatus.CONFIRMED);
+        assertThat(response.getBody().getTotalPrice()).isEqualByComparingTo("75.00");
+    }
+
+    @Test
+    void deleteBooking_shouldReturn204AndSubsequentGetReturns404() {
+        BookingResponseDTO created =
+                restTemplate.postForObject("/api/bookings", buildRequest(1L, 10L), BookingResponseDTO.class);
+
+        ResponseEntity<Void> deleteResponse = restTemplate.exchange(
+                "/api/bookings/" + created.getId(), HttpMethod.DELETE, null, Void.class);
+
+        assertThat(deleteResponse.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+        ResponseEntity<String> getResponse =
+                restTemplate.getForEntity("/api/bookings/" + created.getId(), String.class);
+        assertThat(getResponse.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(bookingRepository.existsById(created.getId())).isFalse();
+    }
+
+    @Test
+    void createBooking_shouldReturn400_whenEndTimeIsBeforeStartTime() {
+        LocalDateTime start = LocalDateTime.now().plusDays(2).withHour(10).withMinute(0).withSecond(0).withNano(0);
+        BookingRequestDTO invalid = BookingRequestDTO.builder()
+                .userId(1L)
+                .facilityId(10L)
+                .startTime(start)
+                .endTime(start.minusHours(1))   // end < start
+                .totalPrice(new BigDecimal("50.00"))
+                .build();
+
+        ResponseEntity<String> response = restTemplate.postForEntity("/api/bookings", invalid, String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(bookingRepository.count()).isZero();
+    }
+}

--- a/Booking Service/src/test/java/ba/nwt/bookingservice/integration/BookingRecurringFlowIT.java
+++ b/Booking Service/src/test/java/ba/nwt/bookingservice/integration/BookingRecurringFlowIT.java
@@ -1,0 +1,151 @@
+package ba.nwt.bookingservice.integration;
+
+import ba.nwt.bookingservice.dto.BookingRequestDTO;
+import ba.nwt.bookingservice.dto.BookingResponseDTO;
+import ba.nwt.bookingservice.model.Booking;
+import ba.nwt.bookingservice.repository.BookingRepository;
+import ba.nwt.bookingservice.repository.BookingUserRepository;
+import ba.nwt.bookingservice.repository.EquipmentRentalRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Flow: kreiranje recurring (ponavljajućih) rezervacija.
+ * Testira tačan broj kreiranog, intervale između rezervacija,
+ * isRecurring flag i prekid na konfliktu.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class BookingRecurringFlowIT {
+
+    @MockBean
+    private RabbitTemplate rabbitTemplate;
+
+    @Autowired private TestRestTemplate restTemplate;
+    @Autowired private BookingRepository bookingRepository;
+    @Autowired private BookingUserRepository bookingUserRepository;
+    @Autowired private EquipmentRentalRepository equipmentRentalRepository;
+
+    @BeforeEach
+    void cleanUp() {
+        bookingUserRepository.deleteAll();
+        equipmentRentalRepository.deleteAll();
+        bookingRepository.deleteAll();
+    }
+
+    private List<BookingResponseDTO> postRecurring(LocalDateTime start, LocalDateTime end,
+                                                    Long facilityId, String pattern, int occurrences) {
+        String url = UriComponentsBuilder.fromPath("/api/bookings/recurring")
+                .queryParam("pattern", pattern)
+                .queryParam("occurrences", occurrences)
+                .toUriString();
+
+        ResponseEntity<List<BookingResponseDTO>> resp = restTemplate.exchange(
+                url, HttpMethod.POST,
+                new HttpEntity<>(BookingRequestDTO.builder()
+                        .userId(1L).facilityId(facilityId)
+                        .startTime(start).endTime(end)
+                        .totalPrice(new BigDecimal("80.00")).build()),
+                new ParameterizedTypeReference<List<BookingResponseDTO>>() {});
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        return resp.getBody();
+    }
+
+    @Test
+    void createFourWeeklyBookings_allPersistedAndReturnedInResponse() {
+        LocalDateTime start = LocalDateTime.now().plusDays(14).withHour(10).withMinute(0).withSecond(0).withNano(0);
+
+        List<BookingResponseDTO> bookings = postRecurring(start, start.plusHours(2), 10L, "WEEKLY", 4);
+
+        assertThat(bookings).hasSize(4);
+        assertThat(bookingRepository.count()).isEqualTo(4);
+    }
+
+    @Test
+    void weeklyRecurring_eachBookingIsExactlySevenDaysAfterPrevious() {
+        LocalDateTime start = LocalDateTime.now().plusDays(15).withHour(10).withMinute(0).withSecond(0).withNano(0);
+
+        List<BookingResponseDTO> bookings = postRecurring(start, start.plusHours(2), 11L, "WEEKLY", 4);
+
+        for (int i = 1; i < bookings.size(); i++) {
+            long daysBetween = ChronoUnit.DAYS.between(
+                    bookings.get(i - 1).getStartTime(),
+                    bookings.get(i).getStartTime());
+            assertThat(daysBetween).isEqualTo(7);
+        }
+    }
+
+    @Test
+    void allRecurringBookings_haveIsRecurringFlagSetToTrue() {
+        LocalDateTime start = LocalDateTime.now().plusDays(16).withHour(10).withMinute(0).withSecond(0).withNano(0);
+
+        List<BookingResponseDTO> bookings = postRecurring(start, start.plusHours(2), 12L, "WEEKLY", 3);
+
+        assertThat(bookings).allMatch(b -> Boolean.TRUE.equals(b.getIsRecurring()));
+        bookingRepository.findAll().forEach(b ->
+                assertThat(b.getIsRecurring()).isTrue());
+    }
+
+    @Test
+    void dailyRecurring_shouldSpanConsecutiveDays() {
+        LocalDateTime start = LocalDateTime.now().plusDays(17).withHour(9).withMinute(0).withSecond(0).withNano(0);
+
+        List<BookingResponseDTO> bookings = postRecurring(start, start.plusHours(1), 13L, "DAILY", 5);
+
+        assertThat(bookings).hasSize(5);
+        for (int i = 1; i < bookings.size(); i++) {
+            long daysBetween = ChronoUnit.DAYS.between(
+                    bookings.get(i - 1).getStartTime(),
+                    bookings.get(i).getStartTime());
+            assertThat(daysBetween).isEqualTo(1);
+        }
+    }
+
+    @Test
+    void recurringCreation_atomicallyRollsBack_whenConflictOccursOnLaterOccurrence() {
+        LocalDateTime base = LocalDateTime.now().plusDays(18).withHour(10).withMinute(0).withSecond(0).withNano(0);
+
+        // Zauzmi treću sedmicu (occurrence index=2) za isti facility
+        restTemplate.postForObject("/api/bookings",
+                BookingRequestDTO.builder()
+                        .userId(2L).facilityId(14L)
+                        .startTime(base.plusWeeks(2)).endTime(base.plusWeeks(2).plusHours(2))
+                        .totalPrice(new BigDecimal("100.00"))
+                        .status(Booking.BookingStatus.PENDING).build(),
+                BookingResponseDTO.class);
+
+        // Pokušaj kreirati 4 weekly bookings — treća se sukobi s postojećom
+        String url = UriComponentsBuilder.fromPath("/api/bookings/recurring")
+                .queryParam("pattern", "WEEKLY").queryParam("occurrences", "4")
+                .toUriString();
+        ResponseEntity<String> resp = restTemplate.exchange(url, HttpMethod.POST,
+                new HttpEntity<>(BookingRequestDTO.builder()
+                        .userId(1L).facilityId(14L)
+                        .startTime(base).endTime(base.plusHours(2))
+                        .totalPrice(new BigDecimal("80.00")).build()),
+                String.class);
+
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        // Samo originalni booking ostaje — rollback sprečio kreiranje recurring
+        assertThat(bookingRepository.count()).isEqualTo(1);
+    }
+}

--- a/Booking Service/src/test/java/ba/nwt/bookingservice/integration/BookingStatusLifecycleIT.java
+++ b/Booking Service/src/test/java/ba/nwt/bookingservice/integration/BookingStatusLifecycleIT.java
@@ -1,0 +1,152 @@
+package ba.nwt.bookingservice.integration;
+
+import ba.nwt.bookingservice.dto.BookingRequestDTO;
+import ba.nwt.bookingservice.dto.BookingResponseDTO;
+import ba.nwt.bookingservice.model.Booking;
+import ba.nwt.bookingservice.repository.BookingRepository;
+import ba.nwt.bookingservice.repository.BookingUserRepository;
+import ba.nwt.bookingservice.repository.EquipmentRentalRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Flow: životni ciklus statusa rezervacije.
+ * Testira prijelaze između statusa i ispravno filtriranje po statusu.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class BookingStatusLifecycleIT {
+
+    @MockBean
+    private RabbitTemplate rabbitTemplate;
+
+    @Autowired private TestRestTemplate restTemplate;
+    @Autowired private BookingRepository bookingRepository;
+    @Autowired private BookingUserRepository bookingUserRepository;
+    @Autowired private EquipmentRentalRepository equipmentRentalRepository;
+
+    @BeforeEach
+    void cleanUp() {
+        bookingUserRepository.deleteAll();
+        equipmentRentalRepository.deleteAll();
+        bookingRepository.deleteAll();
+    }
+
+    private BookingResponseDTO createPendingBooking(int dayOffset) {
+        LocalDateTime start = LocalDateTime.now().plusDays(dayOffset).withHour(10).withMinute(0).withSecond(0).withNano(0);
+        return restTemplate.postForObject("/api/bookings",
+                BookingRequestDTO.builder()
+                        .userId(1L).facilityId(10L)
+                        .startTime(start).endTime(start.plusHours(2))
+                        .totalPrice(new BigDecimal("100.00"))
+                        .status(Booking.BookingStatus.PENDING)
+                        .build(),
+                BookingResponseDTO.class);
+    }
+
+    private BookingResponseDTO updateStatus(Long id, Booking.BookingStatus newStatus,
+                                            LocalDateTime start, LocalDateTime end) {
+        ResponseEntity<BookingResponseDTO> resp = restTemplate.exchange(
+                "/api/bookings/" + id, HttpMethod.PUT,
+                new HttpEntity<>(BookingRequestDTO.builder()
+                        .userId(1L).facilityId(10L)
+                        .startTime(start).endTime(end)
+                        .totalPrice(new BigDecimal("100.00"))
+                        .status(newStatus).build()),
+                BookingResponseDTO.class);
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
+        return resp.getBody();
+    }
+
+    @Test
+    void pendingBooking_canBeConfirmed_statusPersistsInDatabase() {
+        BookingResponseDTO booking = createPendingBooking(7);
+        assertThat(booking.getStatus()).isEqualTo(Booking.BookingStatus.PENDING);
+
+        LocalDateTime start = booking.getStartTime();
+        BookingResponseDTO confirmed = updateStatus(booking.getId(), Booking.BookingStatus.CONFIRMED, start, start.plusHours(2));
+
+        assertThat(confirmed.getStatus()).isEqualTo(Booking.BookingStatus.CONFIRMED);
+        // Verify directly in database
+        assertThat(bookingRepository.findById(booking.getId()).get().getStatus())
+                .isEqualTo(Booking.BookingStatus.CONFIRMED);
+    }
+
+    @Test
+    void confirmedBooking_canBeCompleted_fullLifecycle() {
+        BookingResponseDTO booking = createPendingBooking(8);
+        LocalDateTime start = booking.getStartTime();
+
+        // PENDING → CONFIRMED
+        updateStatus(booking.getId(), Booking.BookingStatus.CONFIRMED, start, start.plusHours(2));
+
+        // CONFIRMED → COMPLETED
+        BookingResponseDTO completed = updateStatus(booking.getId(), Booking.BookingStatus.COMPLETED, start, start.plusHours(2));
+
+        assertThat(completed.getStatus()).isEqualTo(Booking.BookingStatus.COMPLETED);
+        assertThat(bookingRepository.findById(booking.getId()).get().getStatus())
+                .isEqualTo(Booking.BookingStatus.COMPLETED);
+    }
+
+    @Test
+    void cancelledBooking_doesNotAppearInPendingFilter() {
+        BookingResponseDTO b1 = createPendingBooking(9);
+        BookingResponseDTO b2 = createPendingBooking(10);
+        LocalDateTime s1 = b1.getStartTime();
+
+        // Cancel first
+        updateStatus(b1.getId(), Booking.BookingStatus.CANCELLED, s1, s1.plusHours(2));
+
+        ResponseEntity<List<BookingResponseDTO>> pending = restTemplate.exchange(
+                "/api/bookings/status/PENDING", HttpMethod.GET, null,
+                new ParameterizedTypeReference<List<BookingResponseDTO>>() {});
+
+        assertThat(pending.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(pending.getBody()).hasSize(1);
+        assertThat(pending.getBody().get(0).getId()).isEqualTo(b2.getId());
+    }
+
+    @Test
+    void mixedStatusBookings_filterReturnsOnlyCorrectStatus() {
+        BookingResponseDTO b1 = createPendingBooking(11);  // ostat će PENDING
+        BookingResponseDTO b2 = createPendingBooking(12);  // ići u CONFIRMED
+        BookingResponseDTO b3 = createPendingBooking(13);  // ići u COMPLETED
+        LocalDateTime s2 = b2.getStartTime();
+        LocalDateTime s3 = b3.getStartTime();
+
+        updateStatus(b2.getId(), Booking.BookingStatus.CONFIRMED, s2, s2.plusHours(2));
+        updateStatus(b3.getId(), Booking.BookingStatus.CONFIRMED, s3, s3.plusHours(2));
+        updateStatus(b3.getId(), Booking.BookingStatus.COMPLETED, s3, s3.plusHours(2));
+
+        ResponseEntity<List<BookingResponseDTO>> pending = restTemplate.exchange(
+                "/api/bookings/status/PENDING", HttpMethod.GET, null,
+                new ParameterizedTypeReference<List<BookingResponseDTO>>() {});
+        ResponseEntity<List<BookingResponseDTO>> confirmed = restTemplate.exchange(
+                "/api/bookings/status/CONFIRMED", HttpMethod.GET, null,
+                new ParameterizedTypeReference<List<BookingResponseDTO>>() {});
+        ResponseEntity<List<BookingResponseDTO>> completed = restTemplate.exchange(
+                "/api/bookings/status/COMPLETED", HttpMethod.GET, null,
+                new ParameterizedTypeReference<List<BookingResponseDTO>>() {});
+
+        assertThat(pending.getBody()).hasSize(1).allMatch(b -> b.getId().equals(b1.getId()));
+        assertThat(confirmed.getBody()).hasSize(1).allMatch(b -> b.getId().equals(b2.getId()));
+        assertThat(completed.getBody()).hasSize(1).allMatch(b -> b.getId().equals(b3.getId()));
+    }
+}

--- a/Booking Service/src/test/java/ba/nwt/bookingservice/integration/ReviewCrudIT.java
+++ b/Booking Service/src/test/java/ba/nwt/bookingservice/integration/ReviewCrudIT.java
@@ -1,0 +1,188 @@
+package ba.nwt.bookingservice.integration;
+
+import ba.nwt.bookingservice.dto.ReviewRequestDTO;
+import ba.nwt.bookingservice.dto.ReviewResponseDTO;
+import ba.nwt.bookingservice.model.Review;
+import ba.nwt.bookingservice.repository.ReviewRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for Review CRUD operations.
+ * Review has no Feign dependencies — full HTTP + H2 stack, no mocks.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class ReviewCrudIT {
+
+    @MockBean
+    private RabbitTemplate rabbitTemplate;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private ReviewRepository reviewRepository;
+
+    @BeforeEach
+    void cleanUp() {
+        reviewRepository.deleteAll();
+    }
+
+    private ReviewRequestDTO buildRequest(Long reviewerId, Long entityId,
+                                          Review.ReviewedEntityType type, int rating) {
+        return ReviewRequestDTO.builder()
+                .reviewerId(reviewerId)
+                .reviewedEntityId(entityId)
+                .reviewedEntityType(type)
+                .rating(rating)
+                .comment("Test comment rating=" + rating)
+                .build();
+    }
+
+    @Test
+    void createReview_shouldReturn201AndPersistToDatabase() {
+        ReviewRequestDTO request = buildRequest(1L, 10L, Review.ReviewedEntityType.FACILITY, 5);
+
+        ResponseEntity<ReviewResponseDTO> response =
+                restTemplate.postForEntity("/api/reviews", request, ReviewResponseDTO.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getId()).isPositive();
+        assertThat(response.getBody().getReviewerId()).isEqualTo(1L);
+        assertThat(response.getBody().getReviewedEntityId()).isEqualTo(10L);
+        assertThat(response.getBody().getRating()).isEqualTo(5);
+        assertThat(response.getBody().getReviewedEntityType()).isEqualTo(Review.ReviewedEntityType.FACILITY);
+        assertThat(reviewRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    void getReviewById_shouldReturn200WithPersistedData() {
+        ReviewResponseDTO created = restTemplate.postForObject(
+                "/api/reviews", buildRequest(2L, 20L, Review.ReviewedEntityType.EQUIPMENT, 4), ReviewResponseDTO.class);
+
+        ResponseEntity<ReviewResponseDTO> response =
+                restTemplate.getForEntity("/api/reviews/" + created.getId(), ReviewResponseDTO.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getReviewerId()).isEqualTo(2L);
+        assertThat(response.getBody().getRating()).isEqualTo(4);
+        assertThat(response.getBody().getReviewedEntityType()).isEqualTo(Review.ReviewedEntityType.EQUIPMENT);
+    }
+
+    @Test
+    void getReviewsByReviewer_shouldReturnOnlyThatReviewersReviews() {
+        restTemplate.postForObject("/api/reviews", buildRequest(7L, 10L, Review.ReviewedEntityType.FACILITY, 5), ReviewResponseDTO.class);
+        restTemplate.postForObject("/api/reviews", buildRequest(7L, 11L, Review.ReviewedEntityType.FACILITY, 3), ReviewResponseDTO.class);
+        restTemplate.postForObject("/api/reviews", buildRequest(8L, 10L, Review.ReviewedEntityType.FACILITY, 4), ReviewResponseDTO.class);
+
+        ResponseEntity<List<ReviewResponseDTO>> response = restTemplate.exchange(
+                "/api/reviews/reviewer/7",
+                HttpMethod.GET, null,
+                new ParameterizedTypeReference<List<ReviewResponseDTO>>() {});
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(2);
+        assertThat(response.getBody()).allMatch(r -> r.getReviewerId().equals(7L));
+    }
+
+    @Test
+    void getReviewsByEntity_shouldReturnReviewsForThatEntity() {
+        restTemplate.postForObject("/api/reviews", buildRequest(1L, 50L, Review.ReviewedEntityType.FACILITY, 5), ReviewResponseDTO.class);
+        restTemplate.postForObject("/api/reviews", buildRequest(2L, 50L, Review.ReviewedEntityType.FACILITY, 3), ReviewResponseDTO.class);
+        restTemplate.postForObject("/api/reviews", buildRequest(3L, 99L, Review.ReviewedEntityType.FACILITY, 4), ReviewResponseDTO.class);
+
+        ResponseEntity<List<ReviewResponseDTO>> response = restTemplate.exchange(
+                "/api/reviews/entity/FACILITY/50",
+                HttpMethod.GET, null,
+                new ParameterizedTypeReference<List<ReviewResponseDTO>>() {});
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(2);
+        assertThat(response.getBody()).allMatch(r -> r.getReviewedEntityId().equals(50L));
+    }
+
+    @Test
+    void updateReview_shouldReturn200WithModifiedData() {
+        ReviewResponseDTO created = restTemplate.postForObject(
+                "/api/reviews", buildRequest(1L, 10L, Review.ReviewedEntityType.FACILITY, 3), ReviewResponseDTO.class);
+
+        ReviewRequestDTO updateRequest = ReviewRequestDTO.builder()
+                .reviewerId(1L)
+                .reviewedEntityId(10L)
+                .reviewedEntityType(Review.ReviewedEntityType.FACILITY)
+                .rating(5)
+                .comment("Updated — excellent facility!")
+                .build();
+
+        ResponseEntity<ReviewResponseDTO> response = restTemplate.exchange(
+                "/api/reviews/" + created.getId(),
+                HttpMethod.PUT,
+                new HttpEntity<>(updateRequest),
+                ReviewResponseDTO.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getRating()).isEqualTo(5);
+        assertThat(response.getBody().getComment()).isEqualTo("Updated — excellent facility!");
+    }
+
+    @Test
+    void deleteReview_shouldReturn204AndSubsequentGetReturns404() {
+        ReviewResponseDTO created = restTemplate.postForObject(
+                "/api/reviews", buildRequest(1L, 10L, Review.ReviewedEntityType.FACILITY, 4), ReviewResponseDTO.class);
+
+        ResponseEntity<Void> deleteResponse = restTemplate.exchange(
+                "/api/reviews/" + created.getId(), HttpMethod.DELETE, null, Void.class);
+
+        assertThat(deleteResponse.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+        ResponseEntity<String> getResponse =
+                restTemplate.getForEntity("/api/reviews/" + created.getId(), String.class);
+        assertThat(getResponse.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(reviewRepository.existsById(created.getId())).isFalse();
+    }
+
+    @Test
+    void createReview_shouldReturn400_whenRatingExceedsMaximum() {
+        ReviewRequestDTO invalid = ReviewRequestDTO.builder()
+                .reviewerId(1L)
+                .reviewedEntityId(10L)
+                .reviewedEntityType(Review.ReviewedEntityType.FACILITY)
+                .rating(6)   // max is 5
+                .build();
+
+        ResponseEntity<String> response = restTemplate.postForEntity("/api/reviews", invalid, String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(reviewRepository.count()).isZero();
+    }
+
+    @Test
+    void createReview_shouldReturn400_whenRatingIsBelowMinimum() {
+        ReviewRequestDTO invalid = ReviewRequestDTO.builder()
+                .reviewerId(1L)
+                .reviewedEntityId(10L)
+                .reviewedEntityType(Review.ReviewedEntityType.FACILITY)
+                .rating(0)   // min is 1
+                .build();
+
+        ResponseEntity<String> response = restTemplate.postForEntity("/api/reviews", invalid, String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+}

--- a/Booking Service/src/test/resources/application-test.properties
+++ b/Booking Service/src/test/resources/application-test.properties
@@ -1,5 +1,7 @@
 # ── Test Configuration — H2 In-Memory ──
-spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false;MODE=MYSQL
+server.port=0
+
+spring.datasource.url=jdbc:h2:mem:bookingservicetestdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false;MODE=MYSQL
 spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=
@@ -13,11 +15,16 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
 
 spring.main.allow-bean-definition-overriding=true
 
-# ── Z5 — Disable Feign load-balancer & circuit-breaker for slice tests ──
+# ── Disable external services ──
 spring.cloud.openfeign.circuitbreaker.enabled=false
 spring.cloud.discovery.enabled=false
 eureka.client.enabled=false
+eureka.client.register-with-eureka=false
+eureka.client.fetch-registry=false
+spring.cloud.config.enabled=false
+spring.cloud.config.import-check.enabled=false
+spring.config.import=optional:configserver:
 
-# ── Z8 — Disable RabbitMQ auto-connect in unit/slice tests ───────────────────
+# ── Disable RabbitMQ ──
 spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration
 

--- a/INTEGRATION_TESTS.md
+++ b/INTEGRATION_TESTS.md
@@ -1,0 +1,158 @@
+# Integracijski testovi — SportsCenterSystem
+
+## Šta su integracijski testovi?
+
+Integracijski testovi (za razliku od unit testova) pokreću **cijeli Spring kontekst** i koriste **H2 in-memory bazu** umjesto prave MySQL baze. HTTP zahtjevi prolaze kroz cijeli stack:
+
+```
+TestRestTemplate → [Controller] → [Service] → [Repository] → [H2 baza]
+```
+
+Nema mocka — svaki sloj je realan. Testiraju se **tokovi** koji imaju više koraka, promjene stanja i biznis pravila, ne samo izolovane operacije.
+
+## Lokacija testova
+
+Konvencija: sufiks `IT` (Maven Failsafe standard za integration tests).
+
+```
+User Service/src/test/java/ba/nwt/userservice/integration/
+├── UserCrudIT.java                — CRUD lifecycle
+├── UserSearchIT.java              — Paginirana pretraga po roli i ključnoj riječi
+├── UserValidationIT.java          — Validacija inputa i uniqueness constraint
+├── UserAchievementFlowIT.java     — Flow: kreiranje + dodjela + provjera u profilu
+└── UserLoyaltyTierUpgradeIT.java  — Flow: bodovi → tier upgrade → auto achievement
+
+Resource Service/src/test/java/ba/nwt/resourceservice/integration/
+├── FacilityCrudIT.java            — CRUD lifecycle
+├── FacilityFilterIT.java          — Filtriranje po tipu, statusu, ključnoj riječi
+├── FacilityValidationIT.java      — Validacija inputa i biznis pravila
+└── FacilityEquipmentFlowIT.java   — Flow: teren + oprema → link, batch, status promjena
+
+Booking Service/src/test/java/ba/nwt/bookingservice/integration/
+├── BookingCrudIT.java             — CRUD lifecycle
+├── ReviewCrudIT.java              — CRUD lifecycle recenzija + validacija ocjene
+├── BookingConflictFlowIT.java     — Flow: detekcija preklapanja termina
+├── BookingStatusLifecycleIT.java  — Flow: PENDING → CONFIRMED → COMPLETED
+└── BookingRecurringFlowIT.java    — Flow: kreiranje ponavljajućih rezervacija
+
+Payment Service/src/test/java/ba/nwt/paymentservice/integration/
+├── PaymentCrudIT.java             — CRUD lifecycle
+├── PaymentSearchIT.java           — Filtriranje po statusu, metodi, iznosu
+├── PaymentLifecycleIT.java        — Flow: PENDING → PAID → REFUNDED + notifikacija
+└── PaymentRevenueIT.java          — Flow: revenue aggregacija po metodi i datumu
+```
+
+## Šta svaki fajl testira
+
+### User Service (19 + 10 = 29 testova)
+
+| Klasa | Testova | Tip | Šta se testira |
+|-------|---------|-----|----------------|
+| `UserCrudIT` | 7 | CRUD | POST 201, GET by ID/username, PUT, DELETE 204→404, list all |
+| `UserSearchIT` | 5 | Search | Filter po roli, keyword, paginacija, AND filteri, empty result |
+| `UserValidationIT` | 7 | Validation | Username prekratak, invalid email, kratki password, duplikat username/email |
+| `UserAchievementFlowIT` | 5 | **Flow** | Kreiraj user+achievement → dodijeli → vidljivo u profilu → obriši → nestalo; dva korisnika, NOT_FOUND |
+| `UserLoyaltyTierUpgradeIT` | 5 | **Flow** | Dodaj bodove → provjeri total; BRONZE→SILVER auto upgrade; SILVER→GOLD; auto tier achievement; 0 bodova → 400 |
+
+### Resource Service (18 + 5 = 23 testova)
+
+| Klasa | Testova | Tip | Šta se testira |
+|-------|---------|-----|----------------|
+| `FacilityCrudIT` | 6 | CRUD | POST 201, GET by ID/owner, PUT, DELETE 204→404 |
+| `FacilityFilterIT` | 6 | Filter | Type, status, paged search, keyword case-insensitive, list all, kombinirani filteri |
+| `FacilityValidationIT` | 6 | Validation | Hours end < start, missing name/type/ownerId, price=0, capacity=0 |
+| `FacilityEquipmentFlowIT` | 5 | **Flow** | Teren + oprema → link provjera; 3 opreme za isti teren; batch kreiranje; status→MAINTENANCE; filter po tipu |
+
+### Booking Service (15 + 13 = 28 testova)
+
+| Klasa | Testova | Tip | Šta se testira |
+|-------|---------|-----|----------------|
+| `BookingCrudIT` | 7 | CRUD | POST 201, GET by ID/userId/status, PUT, DELETE 204→404, endTime<startTime→400 |
+| `ReviewCrudIT` | 8 | CRUD | POST 201, GET by ID/reviewer/entity, PUT, DELETE, rating>5→400, rating<1→400 |
+| `BookingConflictFlowIT` | 4 | **Flow** | 2 overlapping → oba detektovana; cancel jednog → samo drugi ostaje; recurring na zauzet termin → 400; različiti tereni → nema konflikta |
+| `BookingStatusLifecycleIT` | 4 | **Flow** | PENDING→CONFIRMED persist u DB; CONFIRMED→COMPLETED cijeli lifecycle; cancel uklanja iz pending filtera; mixed statusi filtriranje |
+| `BookingRecurringFlowIT` | 5 | **Flow** | 4 weekly kreirana; 7-dnevni intervali; isRecurring=true; 5 daily uzastopno; atomički rollback na konfliktu u trećoj iteraciji |
+
+### Payment Service (14 + 9 = 23 testova)
+
+| Klasa | Testova | Tip | Šta se testira |
+|-------|---------|-----|----------------|
+| `PaymentCrudIT` | 8 | CRUD | POST 201 + auto transactionId, GET by ID/bookingId/status, PUT, DELETE, amount=0→400 |
+| `PaymentSearchIT` | 6 | Filter | Status, metoda, bookingId, minAmount, paginacija, list all |
+| `PaymentLifecycleIT` | 5 | **Flow** | PAID → paidAt set; PAID→REFUNDED; refund kreira notifikaciju sa transactionId; PENDING ne može biti refundovan; PENDING→PAID→REFUNDED cijeli lifecycle |
+| `PaymentRevenueIT` | 4 | **Flow** | Samo PAID uključeni; breakdown po metodi (CREDIT_CARD vs PAYPAL); plaćanja izvan date range ignorisana; from>to → 400 |
+
+**Ukupno: 103 integracijska testa**
+
+## Tehničke karakteristike
+
+- `@SpringBootTest(webEnvironment = RANDOM_PORT)` — pokreće pravi HTTP server na slučajnom portu
+- `TestRestTemplate` — pravi HTTP pozivi, bez MockMvc
+- `@ActiveProfiles("test")` — aktivira H2 in-memory bazu
+- `@BeforeEach` — čisti bazu u FK-ispravnom redoslijedu prije svakog testa
+- `@MockBean RabbitTemplate` — samo za Booking i Payment servis (RabbitMQ infrastruktura, ne biznis logika)
+
+## Kako pokrenuti
+
+### Svi integracijski testovi jednog servisa
+
+```bash
+cd "User Service"    && ./mvnw test -Dtest="ba.nwt.userservice.integration.*IT"
+cd "Resource Service"&& ./mvnw test -Dtest="ba.nwt.resourceservice.integration.*IT"
+cd "Booking Service" && ./mvnw test -Dtest="ba.nwt.bookingservice.integration.*IT"
+cd "Payment Service" && ./mvnw test -Dtest="ba.nwt.paymentservice.integration.*IT"
+```
+
+### Samo flow testovi
+
+```bash
+cd "Booking Service" && ./mvnw test -Dtest="*FlowIT,*LifecycleIT,*RecurringIT"
+cd "Payment Service" && ./mvnw test -Dtest="*LifecycleIT,*RevenueIT"
+cd "User Service"    && ./mvnw test -Dtest="*FlowIT,*UpgradeIT"
+```
+
+### Jedna klasa ili metoda
+
+```bash
+cd "Booking Service" && ./mvnw test -Dtest="BookingConflictFlowIT"
+cd "Payment Service" && ./mvnw test -Dtest="PaymentLifecycleIT#paidPayment_canBeRefunded_statusChangesToRefunded"
+```
+
+### Svi testovi (unit + integracijski) jednog servisa
+
+```bash
+cd "User Service" && ./mvnw test
+```
+
+## Konfiguracija za testove (`application-test.properties`)
+
+Svaki servis ima `src/test/resources/application-test.properties` koji:
+- Zamjenjuje MySQL → H2 in-memory bazu (jedinstveno ime po servisu: `bookingservicetestdb` itd.)
+- Isključuje Eureka, Config Server, Spring Cloud Discovery
+- Postavlja `server.port=0` (slučajni port)
+- `ddl-auto=create-drop` (svježa shema za svaki context start)
+- Booking/Payment: `spring.autoconfigure.exclude=RabbitAutoConfiguration`
+
+## Konvencija imenovanja
+
+```
+action_shouldExpectedBehaviour()
+action_shouldExpectedBehaviour_whenCondition()
+
+Primjeri:
+  createUser_shouldReturn201AndPersistToDatabase()
+  paidPayment_canBeRefunded_statusChangesToRefunded()
+  crossingBronzeToSilverThreshold_shouldUpgradeTierAutomatically()
+  recurringCreation_atomicallyRollsBack_whenConflictOccursOnLaterOccurrence()
+```
+
+## Napomene
+
+- Spring Test context caching — kontekst se dijeli između testova iste klase (brže)
+- `DataLoader` se pokreće jednom pri startu, `@BeforeEach` čisti DB-state
+- FK redoslijed brisanja:
+  - User Service: `UserAchievement → UserLoyalty → User → Achievement`
+  - Resource Service: `PricingRule → Equipment → Facility`
+  - Booking Service: `BookingUser → EquipmentRental → Booking`
+  - Payment Service: `Notification → Payment`
+- `@MockBean RabbitTemplate` potreban jer Booking/Payment servisi imaju Saga komponente koje injektuju RabbitTemplate — jedini mock u cijelom test setu

--- a/Payment Service/src/test/java/ba/nwt/paymentservice/integration/PaymentCrudIT.java
+++ b/Payment Service/src/test/java/ba/nwt/paymentservice/integration/PaymentCrudIT.java
@@ -1,0 +1,196 @@
+package ba.nwt.paymentservice.integration;
+
+import ba.nwt.paymentservice.dto.PaymentRequestDTO;
+import ba.nwt.paymentservice.dto.PaymentResponseDTO;
+import ba.nwt.paymentservice.model.Payment;
+import ba.nwt.paymentservice.repository.NotificationRepository;
+import ba.nwt.paymentservice.repository.PaymentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for Payment CRUD operations.
+ * Payment service has no Feign calls — full HTTP + H2 stack, no mocks.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class PaymentCrudIT {
+
+    @MockBean
+    private RabbitTemplate rabbitTemplate;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private PaymentRepository paymentRepository;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @BeforeEach
+    void cleanUp() {
+        notificationRepository.deleteAll();
+        paymentRepository.deleteAll();
+    }
+
+    private PaymentRequestDTO buildRequest(Long bookingId, BigDecimal amount, Payment.PaymentMethod method) {
+        return PaymentRequestDTO.builder()
+                .bookingId(bookingId)
+                .amount(amount)
+                .depositAmount(BigDecimal.ZERO)
+                .paymentMethod(method)
+                .status(Payment.PaymentStatus.PENDING)
+                .build();
+    }
+
+    @Test
+    void createPayment_shouldReturn201AndPersistToDatabase() {
+        PaymentRequestDTO request = buildRequest(100L, new BigDecimal("150.00"), Payment.PaymentMethod.CREDIT_CARD);
+
+        ResponseEntity<PaymentResponseDTO> response =
+                restTemplate.postForEntity("/api/payments", request, PaymentResponseDTO.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getId()).isPositive();
+        assertThat(response.getBody().getBookingId()).isEqualTo(100L);
+        assertThat(response.getBody().getAmount()).isEqualByComparingTo("150.00");
+        assertThat(response.getBody().getPaymentMethod()).isEqualTo(Payment.PaymentMethod.CREDIT_CARD);
+        assertThat(response.getBody().getStatus()).isEqualTo(Payment.PaymentStatus.PENDING);
+        assertThat(response.getBody().getTransactionId()).isNotBlank();
+        assertThat(paymentRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    void getPaymentById_shouldReturn200WithPersistedData() {
+        PaymentResponseDTO created = restTemplate.postForObject(
+                "/api/payments", buildRequest(200L, new BigDecimal("80.00"), Payment.PaymentMethod.PAYPAL), PaymentResponseDTO.class);
+
+        ResponseEntity<PaymentResponseDTO> response =
+                restTemplate.getForEntity("/api/payments/" + created.getId(), PaymentResponseDTO.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getBookingId()).isEqualTo(200L);
+        assertThat(response.getBody().getAmount()).isEqualByComparingTo("80.00");
+        assertThat(response.getBody().getPaymentMethod()).isEqualTo(Payment.PaymentMethod.PAYPAL);
+    }
+
+    @Test
+    void getPaymentsByBookingId_shouldReturnOnlyThatBookingsPayments() {
+        restTemplate.postForObject("/api/payments", buildRequest(300L, new BigDecimal("50.00"), Payment.PaymentMethod.CREDIT_CARD), PaymentResponseDTO.class);
+        restTemplate.postForObject("/api/payments", buildRequest(300L, new BigDecimal("25.00"), Payment.PaymentMethod.DEBIT_CARD), PaymentResponseDTO.class);
+        restTemplate.postForObject("/api/payments", buildRequest(999L, new BigDecimal("75.00"), Payment.PaymentMethod.PAYPAL), PaymentResponseDTO.class);
+
+        ResponseEntity<List<PaymentResponseDTO>> response = restTemplate.exchange(
+                "/api/payments/booking/300",
+                HttpMethod.GET, null,
+                new ParameterizedTypeReference<List<PaymentResponseDTO>>() {});
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(2);
+        assertThat(response.getBody()).allMatch(p -> p.getBookingId().equals(300L));
+    }
+
+    @Test
+    void getPaymentsByStatus_shouldReturnOnlyMatchingStatus() {
+        restTemplate.postForObject("/api/payments",
+                PaymentRequestDTO.builder().bookingId(1L).amount(new BigDecimal("100.00"))
+                        .paymentMethod(Payment.PaymentMethod.CREDIT_CARD)
+                        .status(Payment.PaymentStatus.PAID).build(),
+                PaymentResponseDTO.class);
+        restTemplate.postForObject("/api/payments",
+                buildRequest(2L, new BigDecimal("50.00"), Payment.PaymentMethod.DEBIT_CARD),
+                PaymentResponseDTO.class);
+
+        ResponseEntity<List<PaymentResponseDTO>> response = restTemplate.exchange(
+                "/api/payments/status/PAID",
+                HttpMethod.GET, null,
+                new ParameterizedTypeReference<List<PaymentResponseDTO>>() {});
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(1);
+        assertThat(response.getBody().get(0).getStatus()).isEqualTo(Payment.PaymentStatus.PAID);
+    }
+
+    @Test
+    void updatePayment_shouldReturn200WithModifiedData() {
+        PaymentResponseDTO created = restTemplate.postForObject(
+                "/api/payments", buildRequest(400L, new BigDecimal("120.00"), Payment.PaymentMethod.CREDIT_CARD), PaymentResponseDTO.class);
+
+        PaymentRequestDTO updateRequest = PaymentRequestDTO.builder()
+                .bookingId(400L)
+                .amount(new BigDecimal("120.00"))
+                .paymentMethod(Payment.PaymentMethod.PAYPAL)
+                .status(Payment.PaymentStatus.PAID)
+                .build();
+
+        ResponseEntity<PaymentResponseDTO> response = restTemplate.exchange(
+                "/api/payments/" + created.getId(),
+                HttpMethod.PUT,
+                new HttpEntity<>(updateRequest),
+                PaymentResponseDTO.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getStatus()).isEqualTo(Payment.PaymentStatus.PAID);
+        assertThat(response.getBody().getPaymentMethod()).isEqualTo(Payment.PaymentMethod.PAYPAL);
+    }
+
+    @Test
+    void deletePayment_shouldReturn204AndSubsequentGetReturns404() {
+        PaymentResponseDTO created = restTemplate.postForObject(
+                "/api/payments", buildRequest(500L, new BigDecimal("60.00"), Payment.PaymentMethod.DEBIT_CARD), PaymentResponseDTO.class);
+
+        ResponseEntity<Void> deleteResponse = restTemplate.exchange(
+                "/api/payments/" + created.getId(), HttpMethod.DELETE, null, Void.class);
+
+        assertThat(deleteResponse.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+        ResponseEntity<String> getResponse =
+                restTemplate.getForEntity("/api/payments/" + created.getId(), String.class);
+        assertThat(getResponse.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(paymentRepository.existsById(created.getId())).isFalse();
+    }
+
+    @Test
+    void createPayment_shouldReturn400_whenAmountIsZero() {
+        PaymentRequestDTO invalid = PaymentRequestDTO.builder()
+                .bookingId(1L)
+                .amount(new BigDecimal("0.00"))
+                .paymentMethod(Payment.PaymentMethod.CREDIT_CARD)
+                .build();
+
+        ResponseEntity<String> response = restTemplate.postForEntity("/api/payments", invalid, String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(paymentRepository.count()).isZero();
+    }
+
+    @Test
+    void createPayment_shouldReturn400_whenPaymentMethodIsMissing() {
+        PaymentRequestDTO invalid = PaymentRequestDTO.builder()
+                .bookingId(1L)
+                .amount(new BigDecimal("50.00"))
+                .build();
+
+        ResponseEntity<String> response = restTemplate.postForEntity("/api/payments", invalid, String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(paymentRepository.count()).isZero();
+    }
+}

--- a/Payment Service/src/test/java/ba/nwt/paymentservice/integration/PaymentLifecycleIT.java
+++ b/Payment Service/src/test/java/ba/nwt/paymentservice/integration/PaymentLifecycleIT.java
@@ -1,0 +1,157 @@
+package ba.nwt.paymentservice.integration;
+
+import ba.nwt.paymentservice.dto.PaymentRequestDTO;
+import ba.nwt.paymentservice.dto.PaymentResponseDTO;
+import ba.nwt.paymentservice.model.Notification;
+import ba.nwt.paymentservice.model.Payment;
+import ba.nwt.paymentservice.repository.NotificationRepository;
+import ba.nwt.paymentservice.repository.PaymentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Flow: životni ciklus plaćanja — PENDING → PAID → REFUNDED.
+ * Testira da refund mijenja status, da se kreira notifikacija,
+ * i da se ne može refundovati plaćanje koje nije u statusu PAID.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class PaymentLifecycleIT {
+
+    @MockBean
+    private RabbitTemplate rabbitTemplate;
+
+    @Autowired private TestRestTemplate restTemplate;
+    @Autowired private PaymentRepository paymentRepository;
+    @Autowired private NotificationRepository notificationRepository;
+
+    @BeforeEach
+    void cleanUp() {
+        notificationRepository.deleteAll();
+        paymentRepository.deleteAll();
+    }
+
+    private PaymentResponseDTO createPayment(Payment.PaymentStatus status) {
+        return restTemplate.postForObject("/api/payments",
+                PaymentRequestDTO.builder()
+                        .bookingId(100L)
+                        .amount(new BigDecimal("150.00"))
+                        .depositAmount(BigDecimal.ZERO)
+                        .paymentMethod(Payment.PaymentMethod.CREDIT_CARD)
+                        .status(status)
+                        .build(),
+                PaymentResponseDTO.class);
+    }
+
+    private PaymentResponseDTO updatePayment(Long id, Payment.PaymentStatus newStatus) {
+        ResponseEntity<PaymentResponseDTO> resp = restTemplate.exchange(
+                "/api/payments/" + id, HttpMethod.PUT,
+                new HttpEntity<>(PaymentRequestDTO.builder()
+                        .bookingId(100L)
+                        .amount(new BigDecimal("150.00"))
+                        .paymentMethod(Payment.PaymentMethod.CREDIT_CARD)
+                        .status(newStatus).build()),
+                PaymentResponseDTO.class);
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
+        return resp.getBody();
+    }
+
+    @Test
+    void createPaidPayment_shouldHavePaidAtTimestampSet() {
+        PaymentResponseDTO payment = createPayment(Payment.PaymentStatus.PAID);
+
+        assertThat(payment.getStatus()).isEqualTo(Payment.PaymentStatus.PAID);
+        assertThat(payment.getPaidAt()).isNotNull();
+    }
+
+    @Test
+    void paidPayment_canBeRefunded_statusChangesToRefunded() {
+        PaymentResponseDTO payment = createPayment(Payment.PaymentStatus.PAID);
+
+        String url = UriComponentsBuilder.fromPath("/api/payments/{id}/refund")
+                .queryParam("recipientUserId", 5L)
+                .queryParam("reason", "Customer request")
+                .buildAndExpand(payment.getId()).toUriString();
+
+        ResponseEntity<PaymentResponseDTO> resp = restTemplate.exchange(
+                url, HttpMethod.POST, null, PaymentResponseDTO.class);
+
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(resp.getBody().getStatus()).isEqualTo(Payment.PaymentStatus.REFUNDED);
+        // Provjeri u bazi
+        assertThat(paymentRepository.findById(payment.getId()).get().getStatus())
+                .isEqualTo(Payment.PaymentStatus.REFUNDED);
+    }
+
+    @Test
+    void refund_shouldCreateNotificationWithTransactionIdInSubject() {
+        PaymentResponseDTO payment = createPayment(Payment.PaymentStatus.PAID);
+        assertThat(notificationRepository.count()).isZero();
+
+        String url = UriComponentsBuilder.fromPath("/api/payments/{id}/refund")
+                .queryParam("recipientUserId", 7L)
+                .queryParam("reason", "Duplicate payment")
+                .buildAndExpand(payment.getId()).toUriString();
+        restTemplate.exchange(url, HttpMethod.POST, null, PaymentResponseDTO.class);
+
+        List<Notification> notifications = notificationRepository.findAll();
+        assertThat(notifications).hasSize(1);
+        assertThat(notifications.get(0).getUserId()).isEqualTo(7L);
+        assertThat(notifications.get(0).getSubject()).contains(payment.getTransactionId());
+        assertThat(notifications.get(0).getMessage()).contains("Duplicate payment");
+    }
+
+    @Test
+    void pendingPayment_cannotBeRefunded_returns400() {
+        PaymentResponseDTO payment = createPayment(Payment.PaymentStatus.PENDING);
+
+        String url = UriComponentsBuilder.fromPath("/api/payments/{id}/refund")
+                .queryParam("recipientUserId", 1L)
+                .buildAndExpand(payment.getId()).toUriString();
+        ResponseEntity<String> resp = restTemplate.exchange(
+                url, HttpMethod.POST, null, String.class);
+
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        // Status nije promijenjen
+        assertThat(paymentRepository.findById(payment.getId()).get().getStatus())
+                .isEqualTo(Payment.PaymentStatus.PENDING);
+        assertThat(notificationRepository.count()).isZero();
+    }
+
+    @Test
+    void updatePendingToPaid_thenRefund_fullLifecycle() {
+        // Kreiraj kao PENDING
+        PaymentResponseDTO payment = createPayment(Payment.PaymentStatus.PENDING);
+        assertThat(payment.getPaidAt()).isNull();
+
+        // Ažuriraj na PAID
+        PaymentResponseDTO paid = updatePayment(payment.getId(), Payment.PaymentStatus.PAID);
+        assertThat(paid.getStatus()).isEqualTo(Payment.PaymentStatus.PAID);
+
+        // Refunduj
+        String url = UriComponentsBuilder.fromPath("/api/payments/{id}/refund")
+                .queryParam("recipientUserId", 3L)
+                .buildAndExpand(payment.getId()).toUriString();
+        ResponseEntity<PaymentResponseDTO> refunded = restTemplate.exchange(
+                url, HttpMethod.POST, null, PaymentResponseDTO.class);
+
+        assertThat(refunded.getBody().getStatus()).isEqualTo(Payment.PaymentStatus.REFUNDED);
+        assertThat(notificationRepository.count()).isEqualTo(1);
+    }
+}

--- a/Payment Service/src/test/java/ba/nwt/paymentservice/integration/PaymentRevenueIT.java
+++ b/Payment Service/src/test/java/ba/nwt/paymentservice/integration/PaymentRevenueIT.java
@@ -1,0 +1,135 @@
+package ba.nwt.paymentservice.integration;
+
+import ba.nwt.paymentservice.dto.PaymentRequestDTO;
+import ba.nwt.paymentservice.dto.PaymentResponseDTO;
+import ba.nwt.paymentservice.model.Payment;
+import ba.nwt.paymentservice.repository.NotificationRepository;
+import ba.nwt.paymentservice.repository.PaymentRepository;
+import ba.nwt.paymentservice.service.PaymentService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Flow: agregatni revenue izvještaj.
+ * Testira da se broje samo PAID plaćanja, ispravno sumira po metodi
+ * i poštuje vremenski opseg.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class PaymentRevenueIT {
+
+    @MockBean
+    private RabbitTemplate rabbitTemplate;
+
+    @Autowired private TestRestTemplate restTemplate;
+    @Autowired private PaymentRepository paymentRepository;
+    @Autowired private NotificationRepository notificationRepository;
+
+    @BeforeEach
+    void cleanUp() {
+        notificationRepository.deleteAll();
+        paymentRepository.deleteAll();
+    }
+
+    private void createPaidPayment(BigDecimal amount, Payment.PaymentMethod method) {
+        restTemplate.postForObject("/api/payments",
+                PaymentRequestDTO.builder()
+                        .bookingId(1L).amount(amount)
+                        .depositAmount(BigDecimal.ZERO)
+                        .paymentMethod(method)
+                        .status(Payment.PaymentStatus.PAID)
+                        .build(),
+                PaymentResponseDTO.class);
+    }
+
+    private PaymentService.RevenueReport getRevenue(LocalDateTime from, LocalDateTime to) {
+        String url = UriComponentsBuilder.fromPath("/api/payments/revenue")
+                .queryParam("from", from.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+                .queryParam("to", to.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+                .toUriString();
+        return restTemplate.getForObject(url, PaymentService.RevenueReport.class);
+    }
+
+    @Test
+    void revenueReport_shouldSumOnlyPaidPayments_ignoringPending() {
+        createPaidPayment(new BigDecimal("100.00"), Payment.PaymentMethod.CREDIT_CARD);
+        createPaidPayment(new BigDecimal("200.00"), Payment.PaymentMethod.PAYPAL);
+        // PENDING — ne smije biti u prihodima
+        restTemplate.postForObject("/api/payments",
+                PaymentRequestDTO.builder().bookingId(2L).amount(new BigDecimal("999.00"))
+                        .paymentMethod(Payment.PaymentMethod.DEBIT_CARD)
+                        .status(Payment.PaymentStatus.PENDING).build(),
+                PaymentResponseDTO.class);
+
+        PaymentService.RevenueReport report = getRevenue(
+                LocalDateTime.now().minusMinutes(5), LocalDateTime.now().plusMinutes(5));
+
+        assertThat(report.getTotalRevenue()).isEqualByComparingTo("300.00");
+    }
+
+    @Test
+    void revenueReport_shouldBreakdownTotalByPaymentMethod() {
+        createPaidPayment(new BigDecimal("50.00"),  Payment.PaymentMethod.CREDIT_CARD);
+        createPaidPayment(new BigDecimal("70.00"),  Payment.PaymentMethod.CREDIT_CARD);
+        createPaidPayment(new BigDecimal("120.00"), Payment.PaymentMethod.PAYPAL);
+
+        PaymentService.RevenueReport report = getRevenue(
+                LocalDateTime.now().minusMinutes(5), LocalDateTime.now().plusMinutes(5));
+
+        assertThat(report.getTotalRevenue()).isEqualByComparingTo("240.00");
+        assertThat(report.getByMethod()).hasSize(2);
+
+        PaymentService.RevenueByMethod card = report.getByMethod().stream()
+                .filter(r -> r.getMethod() == Payment.PaymentMethod.CREDIT_CARD)
+                .findFirst().orElseThrow();
+        assertThat(card.getTotal()).isEqualByComparingTo("120.00");
+        assertThat(card.getCount()).isEqualTo(2);
+
+        PaymentService.RevenueByMethod paypal = report.getByMethod().stream()
+                .filter(r -> r.getMethod() == Payment.PaymentMethod.PAYPAL)
+                .findFirst().orElseThrow();
+        assertThat(paypal.getTotal()).isEqualByComparingTo("120.00");
+        assertThat(paypal.getCount()).isEqualTo(1);
+    }
+
+    @Test
+    void revenueReport_withNoPaymentsInRange_returnsTotalZero() {
+        createPaidPayment(new BigDecimal("500.00"), Payment.PaymentMethod.CREDIT_CARD);
+
+        // Traži u opsegu koji je daleko u prošlosti
+        PaymentService.RevenueReport report = getRevenue(
+                LocalDateTime.now().minusDays(30), LocalDateTime.now().minusDays(29));
+
+        assertThat(report.getTotalRevenue()).isEqualByComparingTo("0.00");
+        assertThat(report.getByMethod()).isEmpty();
+    }
+
+    @Test
+    void revenueReport_invalidRange_toBeforeFrom_shouldReturn400() {
+        String url = UriComponentsBuilder.fromPath("/api/payments/revenue")
+                .queryParam("from", LocalDateTime.now().plusHours(1).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+                .queryParam("to",   LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+                .toUriString();
+
+        ResponseEntity<String> resp = restTemplate.getForEntity(url, String.class);
+
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+}

--- a/Payment Service/src/test/java/ba/nwt/paymentservice/integration/PaymentSearchIT.java
+++ b/Payment Service/src/test/java/ba/nwt/paymentservice/integration/PaymentSearchIT.java
@@ -1,0 +1,160 @@
+package ba.nwt.paymentservice.integration;
+
+import ba.nwt.paymentservice.dto.PaymentRequestDTO;
+import ba.nwt.paymentservice.dto.PaymentResponseDTO;
+import ba.nwt.paymentservice.model.Payment;
+import ba.nwt.paymentservice.repository.NotificationRepository;
+import ba.nwt.paymentservice.repository.PaymentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for Payment search and filter endpoints.
+ * Validates filtering by status, method, bookingId, and amount range.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class PaymentSearchIT {
+
+    @MockBean
+    private RabbitTemplate rabbitTemplate;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private PaymentRepository paymentRepository;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @BeforeEach
+    void cleanUp() {
+        notificationRepository.deleteAll();
+        paymentRepository.deleteAll();
+    }
+
+    private void createPayment(Long bookingId, BigDecimal amount,
+                               Payment.PaymentMethod method, Payment.PaymentStatus status) {
+        restTemplate.postForObject("/api/payments",
+                PaymentRequestDTO.builder()
+                        .bookingId(bookingId)
+                        .amount(amount)
+                        .depositAmount(BigDecimal.ZERO)
+                        .paymentMethod(method)
+                        .status(status)
+                        .build(),
+                PaymentResponseDTO.class);
+    }
+
+    @Test
+    void searchByStatus_shouldReturnOnlyMatchingPayments() {
+        createPayment(1L, new BigDecimal("100.00"), Payment.PaymentMethod.CREDIT_CARD, Payment.PaymentStatus.PAID);
+        createPayment(2L, new BigDecimal("50.00"), Payment.PaymentMethod.PAYPAL, Payment.PaymentStatus.PENDING);
+        createPayment(3L, new BigDecimal("75.00"), Payment.PaymentMethod.DEBIT_CARD, Payment.PaymentStatus.PAID);
+
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                "/api/payments?status=PAID&page=0&size=10",
+                HttpMethod.GET, null,
+                new ParameterizedTypeReference<Map<String, Object>>() {});
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().get("totalElements")).isEqualTo(2);
+        List<?> content = (List<?>) response.getBody().get("content");
+        assertThat(content).hasSize(2);
+    }
+
+    @Test
+    void searchByMethod_shouldReturnOnlyPaymentsWithThatMethod() {
+        createPayment(1L, new BigDecimal("100.00"), Payment.PaymentMethod.CREDIT_CARD, Payment.PaymentStatus.PENDING);
+        createPayment(2L, new BigDecimal("80.00"), Payment.PaymentMethod.PAYPAL, Payment.PaymentStatus.PENDING);
+        createPayment(3L, new BigDecimal("60.00"), Payment.PaymentMethod.CREDIT_CARD, Payment.PaymentStatus.PAID);
+
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                "/api/payments?method=CREDIT_CARD&page=0&size=10",
+                HttpMethod.GET, null,
+                new ParameterizedTypeReference<Map<String, Object>>() {});
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().get("totalElements")).isEqualTo(2);
+    }
+
+    @Test
+    void searchByBookingId_shouldReturnPaymentsForThatBooking() {
+        createPayment(777L, new BigDecimal("50.00"), Payment.PaymentMethod.CREDIT_CARD, Payment.PaymentStatus.PENDING);
+        createPayment(777L, new BigDecimal("25.00"), Payment.PaymentMethod.DEBIT_CARD, Payment.PaymentStatus.PAID);
+        createPayment(888L, new BigDecimal("100.00"), Payment.PaymentMethod.PAYPAL, Payment.PaymentStatus.PENDING);
+
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                "/api/payments?bookingId=777&page=0&size=10",
+                HttpMethod.GET, null,
+                new ParameterizedTypeReference<Map<String, Object>>() {});
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().get("totalElements")).isEqualTo(2);
+    }
+
+    @Test
+    void searchByMinAmount_shouldReturnOnlyPaymentsAboveThreshold() {
+        createPayment(1L, new BigDecimal("30.00"), Payment.PaymentMethod.CREDIT_CARD, Payment.PaymentStatus.PENDING);
+        createPayment(2L, new BigDecimal("80.00"), Payment.PaymentMethod.CREDIT_CARD, Payment.PaymentStatus.PENDING);
+        createPayment(3L, new BigDecimal("150.00"), Payment.PaymentMethod.CREDIT_CARD, Payment.PaymentStatus.PENDING);
+
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                "/api/payments?minAmount=70.00&page=0&size=10",
+                HttpMethod.GET, null,
+                new ParameterizedTypeReference<Map<String, Object>>() {});
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().get("totalElements")).isEqualTo(2);
+    }
+
+    @Test
+    void searchPaged_shouldRespectPageSizeAndTotalElements() {
+        for (int i = 1; i <= 5; i++) {
+            createPayment((long) i, new BigDecimal(i * 10 + ".00"),
+                    Payment.PaymentMethod.CREDIT_CARD, Payment.PaymentStatus.PENDING);
+        }
+
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                "/api/payments?method=CREDIT_CARD&page=0&size=3",
+                HttpMethod.GET, null,
+                new ParameterizedTypeReference<Map<String, Object>>() {});
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().get("totalElements")).isEqualTo(5);
+        assertThat(response.getBody().get("totalPages")).isEqualTo(2);
+        List<?> content = (List<?>) response.getBody().get("content");
+        assertThat(content).hasSize(3);
+    }
+
+    @Test
+    void getAllPayments_withoutFilters_shouldReturnListOfAll() {
+        createPayment(1L, new BigDecimal("50.00"), Payment.PaymentMethod.CREDIT_CARD, Payment.PaymentStatus.PENDING);
+        createPayment(2L, new BigDecimal("75.00"), Payment.PaymentMethod.PAYPAL, Payment.PaymentStatus.PAID);
+
+        ResponseEntity<List<PaymentResponseDTO>> response = restTemplate.exchange(
+                "/api/payments",
+                HttpMethod.GET, null,
+                new ParameterizedTypeReference<List<PaymentResponseDTO>>() {});
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(2);
+    }
+}

--- a/Payment Service/src/test/resources/application-test.properties
+++ b/Payment Service/src/test/resources/application-test.properties
@@ -1,5 +1,7 @@
 # ── Test Configuration — H2 In-Memory ──
-spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false;MODE=MYSQL
+server.port=0
+
+spring.datasource.url=jdbc:h2:mem:paymentservicetestdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false;MODE=MYSQL
 spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=
@@ -13,5 +15,14 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
 
 spring.main.allow-bean-definition-overriding=true
 
-# ── Z7 — Disable RabbitMQ auto-connect in unit/slice tests ───────────────────
+# ── Disable external services ──
+eureka.client.enabled=false
+eureka.client.register-with-eureka=false
+eureka.client.fetch-registry=false
+spring.cloud.discovery.enabled=false
+spring.cloud.config.enabled=false
+spring.cloud.config.import-check.enabled=false
+spring.config.import=optional:configserver:
+
+# ── Disable RabbitMQ ──
 spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration

--- a/Resource Service/src/test/java/ba/nwt/resourceservice/integration/FacilityCrudIT.java
+++ b/Resource Service/src/test/java/ba/nwt/resourceservice/integration/FacilityCrudIT.java
@@ -1,0 +1,169 @@
+package ba.nwt.resourceservice.integration;
+
+import ba.nwt.resourceservice.dto.FacilityRequestDTO;
+import ba.nwt.resourceservice.dto.FacilityResponseDTO;
+import ba.nwt.resourceservice.model.Facility;
+import ba.nwt.resourceservice.repository.EquipmentRepository;
+import ba.nwt.resourceservice.repository.FacilityRepository;
+import ba.nwt.resourceservice.repository.PricingRuleRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for Facility CRUD operations.
+ * Full Spring context with H2 in-memory database — no mocks.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class FacilityCrudIT {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private FacilityRepository facilityRepository;
+
+    @Autowired
+    private EquipmentRepository equipmentRepository;
+
+    @Autowired
+    private PricingRuleRepository pricingRuleRepository;
+
+    @BeforeEach
+    void cleanUp() {
+        pricingRuleRepository.deleteAll();
+        equipmentRepository.deleteAll();
+        facilityRepository.deleteAll();
+    }
+
+    private FacilityRequestDTO buildRequest(String name, Facility.FacilityType type) {
+        return FacilityRequestDTO.builder()
+                .ownerId(1L)
+                .name(name)
+                .type(type)
+                .capacity(10)
+                .basePricePerHour(new BigDecimal("50.00"))
+                .description("Test facility")
+                .workingHoursStart(LocalTime.of(8, 0))
+                .workingHoursEnd(LocalTime.of(22, 0))
+                .status(Facility.FacilityStatus.ACTIVE)
+                .build();
+    }
+
+    @Test
+    void createFacility_shouldReturn201AndPersistToDatabase() {
+        FacilityRequestDTO request = buildRequest("Tennis Court A", Facility.FacilityType.TENNIS);
+
+        ResponseEntity<FacilityResponseDTO> response =
+                restTemplate.postForEntity("/api/facilities", request, FacilityResponseDTO.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getId()).isPositive();
+        assertThat(response.getBody().getName()).isEqualTo("Tennis Court A");
+        assertThat(response.getBody().getType()).isEqualTo(Facility.FacilityType.TENNIS);
+        assertThat(response.getBody().getStatus()).isEqualTo(Facility.FacilityStatus.ACTIVE);
+        assertThat(response.getBody().getBasePricePerHour()).isEqualByComparingTo("50.00");
+        assertThat(facilityRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    void getFacilityById_shouldReturn200WithPersistedData() {
+        FacilityResponseDTO created = restTemplate.postForObject(
+                "/api/facilities", buildRequest("Padel Court 1", Facility.FacilityType.PADEL), FacilityResponseDTO.class);
+
+        ResponseEntity<FacilityResponseDTO> response =
+                restTemplate.getForEntity("/api/facilities/" + created.getId(), FacilityResponseDTO.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getName()).isEqualTo("Padel Court 1");
+        assertThat(response.getBody().getType()).isEqualTo(Facility.FacilityType.PADEL);
+        assertThat(response.getBody().getOwnerId()).isEqualTo(1L);
+    }
+
+    @Test
+    void updateFacility_shouldReturn200WithModifiedData() {
+        FacilityResponseDTO created = restTemplate.postForObject(
+                "/api/facilities", buildRequest("Old Name", Facility.FacilityType.FOOTBALL_5V5), FacilityResponseDTO.class);
+
+        FacilityRequestDTO updateRequest = FacilityRequestDTO.builder()
+                .ownerId(2L)
+                .name("New Name")
+                .type(Facility.FacilityType.FOOTBALL_7V7)
+                .capacity(14)
+                .basePricePerHour(new BigDecimal("80.00"))
+                .workingHoursStart(LocalTime.of(9, 0))
+                .workingHoursEnd(LocalTime.of(23, 0))
+                .status(Facility.FacilityStatus.ACTIVE)
+                .build();
+
+        ResponseEntity<FacilityResponseDTO> response = restTemplate.exchange(
+                "/api/facilities/" + created.getId(),
+                HttpMethod.PUT,
+                new HttpEntity<>(updateRequest),
+                FacilityResponseDTO.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getName()).isEqualTo("New Name");
+        assertThat(response.getBody().getType()).isEqualTo(Facility.FacilityType.FOOTBALL_7V7);
+        assertThat(response.getBody().getCapacity()).isEqualTo(14);
+        assertThat(response.getBody().getBasePricePerHour()).isEqualByComparingTo("80.00");
+    }
+
+    @Test
+    void deleteFacility_shouldReturn204AndSubsequentGetReturns404() {
+        FacilityResponseDTO created = restTemplate.postForObject(
+                "/api/facilities", buildRequest("To Delete", Facility.FacilityType.TENNIS), FacilityResponseDTO.class);
+
+        ResponseEntity<Void> deleteResponse = restTemplate.exchange(
+                "/api/facilities/" + created.getId(), HttpMethod.DELETE, null, Void.class);
+
+        assertThat(deleteResponse.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+
+        ResponseEntity<String> getResponse =
+                restTemplate.getForEntity("/api/facilities/" + created.getId(), String.class);
+        assertThat(getResponse.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(facilityRepository.existsById(created.getId())).isFalse();
+    }
+
+    @Test
+    void getFacility_shouldReturn404_whenIdDoesNotExist() {
+        ResponseEntity<String> response = restTemplate.getForEntity("/api/facilities/999999", String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    void getFacilitiesByOwner_shouldReturnOnlyOwnersFacilities() {
+        restTemplate.postForObject("/api/facilities",
+                FacilityRequestDTO.builder().ownerId(10L).name("Owner10 Court").type(Facility.FacilityType.PADEL)
+                        .capacity(4).basePricePerHour(new BigDecimal("40.00"))
+                        .workingHoursStart(LocalTime.of(8, 0)).workingHoursEnd(LocalTime.of(22, 0)).build(),
+                FacilityResponseDTO.class);
+        restTemplate.postForObject("/api/facilities",
+                FacilityRequestDTO.builder().ownerId(99L).name("Other Court").type(Facility.FacilityType.TENNIS)
+                        .capacity(4).basePricePerHour(new BigDecimal("35.00"))
+                        .workingHoursStart(LocalTime.of(8, 0)).workingHoursEnd(LocalTime.of(22, 0)).build(),
+                FacilityResponseDTO.class);
+
+        ResponseEntity<FacilityResponseDTO[]> response =
+                restTemplate.getForEntity("/api/facilities/owner/10", FacilityResponseDTO[].class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(1);
+        assertThat(response.getBody()[0].getName()).isEqualTo("Owner10 Court");
+    }
+}

--- a/Resource Service/src/test/java/ba/nwt/resourceservice/integration/FacilityEquipmentFlowIT.java
+++ b/Resource Service/src/test/java/ba/nwt/resourceservice/integration/FacilityEquipmentFlowIT.java
@@ -1,0 +1,171 @@
+package ba.nwt.resourceservice.integration;
+
+import ba.nwt.resourceservice.dto.EquipmentRequestDTO;
+import ba.nwt.resourceservice.dto.EquipmentResponseDTO;
+import ba.nwt.resourceservice.dto.FacilityRequestDTO;
+import ba.nwt.resourceservice.dto.FacilityResponseDTO;
+import ba.nwt.resourceservice.model.Equipment;
+import ba.nwt.resourceservice.model.Facility;
+import ba.nwt.resourceservice.repository.EquipmentRepository;
+import ba.nwt.resourceservice.repository.FacilityRepository;
+import ba.nwt.resourceservice.repository.PricingRuleRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Flow: kreiranje terena sa opremom.
+ * Testira vezu između terena i opreme, batch kreiranje,
+ * promjenu statusa terena i pretragu opreme po tipu.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class FacilityEquipmentFlowIT {
+
+    @Autowired private TestRestTemplate restTemplate;
+    @Autowired private FacilityRepository facilityRepository;
+    @Autowired private EquipmentRepository equipmentRepository;
+    @Autowired private PricingRuleRepository pricingRuleRepository;
+
+    @BeforeEach
+    void cleanUp() {
+        pricingRuleRepository.deleteAll();
+        equipmentRepository.deleteAll();
+        facilityRepository.deleteAll();
+    }
+
+    private FacilityResponseDTO createFacility(String name, Facility.FacilityType type) {
+        return restTemplate.postForObject("/api/facilities",
+                FacilityRequestDTO.builder()
+                        .ownerId(1L).name(name).type(type).capacity(10)
+                        .basePricePerHour(new BigDecimal("50.00"))
+                        .workingHoursStart(LocalTime.of(8, 0))
+                        .workingHoursEnd(LocalTime.of(22, 0))
+                        .status(Facility.FacilityStatus.ACTIVE).build(),
+                FacilityResponseDTO.class);
+    }
+
+    private EquipmentResponseDTO addEquipment(Long facilityId, String name, Equipment.EquipmentType type) {
+        return restTemplate.postForObject("/api/equipment",
+                EquipmentRequestDTO.builder()
+                        .facilityId(facilityId).name(name).type(type)
+                        .quantityTotal(5).quantityAvailable(5)
+                        .pricePerDay(new BigDecimal("10.00"))
+                        .equipmentCondition(Equipment.EquipmentCondition.NEW)
+                        .build(),
+                EquipmentResponseDTO.class);
+    }
+
+    @Test
+    void createFacilityWithEquipment_equipmentLinkedToFacility() {
+        FacilityResponseDTO facility = createFacility("Tennis Club", Facility.FacilityType.TENNIS);
+
+        EquipmentResponseDTO equipment = addEquipment(facility.getId(), "Wilson reket", Equipment.EquipmentType.RACKET);
+
+        assertThat(equipment.getFacilityId()).isEqualTo(facility.getId());
+        assertThat(equipment.getName()).isEqualTo("Wilson reket");
+
+        // Provjeri link kroz GET /api/equipment/facility/{id}
+        ResponseEntity<List<EquipmentResponseDTO>> resp = restTemplate.exchange(
+                "/api/equipment/facility/" + facility.getId(), HttpMethod.GET, null,
+                new ParameterizedTypeReference<List<EquipmentResponseDTO>>() {});
+        assertThat(resp.getBody()).hasSize(1);
+        assertThat(resp.getBody().get(0).getFacilityId()).isEqualTo(facility.getId());
+    }
+
+    @Test
+    void addMultipleEquipmentItemsToFacility_allRetrievableByFacilityId() {
+        FacilityResponseDTO facility = createFacility("Padel Arena", Facility.FacilityType.PADEL);
+
+        addEquipment(facility.getId(), "Bullpadel reket 1", Equipment.EquipmentType.RACKET);
+        addEquipment(facility.getId(), "Bullpadel reket 2", Equipment.EquipmentType.RACKET);
+        addEquipment(facility.getId(), "Padel lopta", Equipment.EquipmentType.BALL);
+
+        ResponseEntity<List<EquipmentResponseDTO>> resp = restTemplate.exchange(
+                "/api/equipment/facility/" + facility.getId(), HttpMethod.GET, null,
+                new ParameterizedTypeReference<List<EquipmentResponseDTO>>() {});
+
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(resp.getBody()).hasSize(3);
+        assertThat(resp.getBody()).allMatch(e -> e.getFacilityId().equals(facility.getId()));
+    }
+
+    @Test
+    void batchEquipmentCreation_allItemsCreatedAtomically() {
+        FacilityResponseDTO facility = createFacility("Fitness Centar", Facility.FacilityType.TABLE_TENNIS);
+
+        List<EquipmentRequestDTO> batch = List.of(
+                EquipmentRequestDTO.builder().facilityId(facility.getId()).name("Bicikl 1")
+                        .type(Equipment.EquipmentType.BICYCLE).quantityTotal(3).quantityAvailable(3)
+                        .pricePerDay(new BigDecimal("15.00")).equipmentCondition(Equipment.EquipmentCondition.NEW).build(),
+                EquipmentRequestDTO.builder().facilityId(facility.getId()).name("Bicikl 2")
+                        .type(Equipment.EquipmentType.BICYCLE).quantityTotal(2).quantityAvailable(2)
+                        .pricePerDay(new BigDecimal("15.00")).equipmentCondition(Equipment.EquipmentCondition.GOOD).build(),
+                EquipmentRequestDTO.builder().facilityId(facility.getId()).name("Trenažer")
+                        .type(Equipment.EquipmentType.FITNESS).quantityTotal(1).quantityAvailable(1)
+                        .pricePerDay(new BigDecimal("20.00")).equipmentCondition(Equipment.EquipmentCondition.NEW).build()
+        );
+
+        ResponseEntity<List<EquipmentResponseDTO>> resp = restTemplate.exchange(
+                "/api/equipment/batch", HttpMethod.POST,
+                new HttpEntity<>(batch),
+                new ParameterizedTypeReference<List<EquipmentResponseDTO>>() {});
+
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(resp.getBody()).hasSize(3);
+        assertThat(equipmentRepository.count()).isEqualTo(3);
+        assertThat(resp.getBody()).allMatch(e -> e.getFacilityId().equals(facility.getId()));
+    }
+
+    @Test
+    void updateFacilityStatusToMaintenance_shouldPersistAndBeReflectedInDatabase() {
+        FacilityResponseDTO facility = createFacility("Teren na renoviranju", Facility.FacilityType.FOOTBALL_5V5);
+        assertThat(facility.getStatus()).isEqualTo(Facility.FacilityStatus.ACTIVE);
+
+        FacilityRequestDTO updateReq = FacilityRequestDTO.builder()
+                .ownerId(1L).name(facility.getName()).type(facility.getType())
+                .capacity(10).basePricePerHour(new BigDecimal("50.00"))
+                .workingHoursStart(LocalTime.of(8, 0)).workingHoursEnd(LocalTime.of(22, 0))
+                .status(Facility.FacilityStatus.MAINTENANCE).build();
+
+        ResponseEntity<FacilityResponseDTO> updated = restTemplate.exchange(
+                "/api/facilities/" + facility.getId(), HttpMethod.PUT,
+                new HttpEntity<>(updateReq), FacilityResponseDTO.class);
+
+        assertThat(updated.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(updated.getBody().getStatus()).isEqualTo(Facility.FacilityStatus.MAINTENANCE);
+        assertThat(facilityRepository.findById(facility.getId()).get().getStatus())
+                .isEqualTo(Facility.FacilityStatus.MAINTENANCE);
+    }
+
+    @Test
+    void getEquipmentByType_shouldReturnOnlyMatchingType() {
+        FacilityResponseDTO facility = createFacility("Multi Sport", Facility.FacilityType.TENNIS);
+
+        addEquipment(facility.getId(), "Reket A", Equipment.EquipmentType.RACKET);
+        addEquipment(facility.getId(), "Reket B", Equipment.EquipmentType.RACKET);
+        addEquipment(facility.getId(), "Lopta",   Equipment.EquipmentType.BALL);
+
+        ResponseEntity<List<EquipmentResponseDTO>> resp = restTemplate.exchange(
+                "/api/equipment/type/RACKET", HttpMethod.GET, null,
+                new ParameterizedTypeReference<List<EquipmentResponseDTO>>() {});
+
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(resp.getBody()).hasSize(2);
+        assertThat(resp.getBody()).allMatch(e -> e.getType() == Equipment.EquipmentType.RACKET);
+    }
+}

--- a/Resource Service/src/test/java/ba/nwt/resourceservice/integration/FacilityFilterIT.java
+++ b/Resource Service/src/test/java/ba/nwt/resourceservice/integration/FacilityFilterIT.java
@@ -1,0 +1,166 @@
+package ba.nwt.resourceservice.integration;
+
+import ba.nwt.resourceservice.dto.FacilityRequestDTO;
+import ba.nwt.resourceservice.dto.FacilityResponseDTO;
+import ba.nwt.resourceservice.model.Facility;
+import ba.nwt.resourceservice.repository.EquipmentRepository;
+import ba.nwt.resourceservice.repository.FacilityRepository;
+import ba.nwt.resourceservice.repository.PricingRuleRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for Facility filter, search, and listing endpoints.
+ * Validates filtering by type, status, keyword, and pagination behaviour.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class FacilityFilterIT {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private FacilityRepository facilityRepository;
+
+    @Autowired
+    private EquipmentRepository equipmentRepository;
+
+    @Autowired
+    private PricingRuleRepository pricingRuleRepository;
+
+    @BeforeEach
+    void cleanUp() {
+        pricingRuleRepository.deleteAll();
+        equipmentRepository.deleteAll();
+        facilityRepository.deleteAll();
+    }
+
+    private void createFacility(String name, Facility.FacilityType type, Facility.FacilityStatus status) {
+        restTemplate.postForObject("/api/facilities",
+                FacilityRequestDTO.builder()
+                        .ownerId(1L)
+                        .name(name)
+                        .type(type)
+                        .capacity(10)
+                        .basePricePerHour(new BigDecimal("50.00"))
+                        .workingHoursStart(LocalTime.of(8, 0))
+                        .workingHoursEnd(LocalTime.of(22, 0))
+                        .status(status)
+                        .build(),
+                FacilityResponseDTO.class);
+    }
+
+    @Test
+    void getByType_shouldReturnOnlyFacilitiesWithMatchingType() {
+        createFacility("Tennis A", Facility.FacilityType.TENNIS, Facility.FacilityStatus.ACTIVE);
+        createFacility("Tennis B", Facility.FacilityType.TENNIS, Facility.FacilityStatus.ACTIVE);
+        createFacility("Football", Facility.FacilityType.FOOTBALL_5V5, Facility.FacilityStatus.ACTIVE);
+
+        ResponseEntity<List<FacilityResponseDTO>> response = restTemplate.exchange(
+                "/api/facilities/type/TENNIS",
+                HttpMethod.GET, null,
+                new ParameterizedTypeReference<List<FacilityResponseDTO>>() {});
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(2);
+        assertThat(response.getBody()).allMatch(f -> f.getType() == Facility.FacilityType.TENNIS);
+    }
+
+    @Test
+    void getByStatus_shouldReturnOnlyFacilitiesWithMatchingStatus() {
+        createFacility("Active A", Facility.FacilityType.PADEL, Facility.FacilityStatus.ACTIVE);
+        createFacility("Active B", Facility.FacilityType.PADEL, Facility.FacilityStatus.ACTIVE);
+        createFacility("Inactive", Facility.FacilityType.TENNIS, Facility.FacilityStatus.INACTIVE);
+
+        ResponseEntity<List<FacilityResponseDTO>> response = restTemplate.exchange(
+                "/api/facilities/status/ACTIVE",
+                HttpMethod.GET, null,
+                new ParameterizedTypeReference<List<FacilityResponseDTO>>() {});
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(2);
+        assertThat(response.getBody()).allMatch(f -> f.getStatus() == Facility.FacilityStatus.ACTIVE);
+    }
+
+    @Test
+    void searchPagedByType_shouldReturnPagedResultsFilteredByType() {
+        for (int i = 1; i <= 4; i++) {
+            createFacility("Padel Court " + i, Facility.FacilityType.PADEL, Facility.FacilityStatus.ACTIVE);
+        }
+        createFacility("Football Field", Facility.FacilityType.FOOTBALL_5V5, Facility.FacilityStatus.ACTIVE);
+
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                "/api/facilities?paged=true&type=PADEL&page=0&size=3",
+                HttpMethod.GET, null,
+                new ParameterizedTypeReference<Map<String, Object>>() {});
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().get("totalElements")).isEqualTo(4);
+        assertThat(response.getBody().get("totalPages")).isEqualTo(2);
+        List<?> content = (List<?>) response.getBody().get("content");
+        assertThat(content).hasSize(3);
+    }
+
+    @Test
+    void searchByKeyword_shouldMatchFacilityNameCaseInsensitive() {
+        createFacility("Zenith Padel Arena", Facility.FacilityType.PADEL, Facility.FacilityStatus.ACTIVE);
+        createFacility("Zenith Tennis Club", Facility.FacilityType.TENNIS, Facility.FacilityStatus.ACTIVE);
+        createFacility("Standard Football", Facility.FacilityType.FOOTBALL_5V5, Facility.FacilityStatus.ACTIVE);
+
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                "/api/facilities?q=zenith&page=0&size=10",
+                HttpMethod.GET, null,
+                new ParameterizedTypeReference<Map<String, Object>>() {});
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().get("totalElements")).isEqualTo(2);
+    }
+
+    @Test
+    void getAll_withoutPagingParam_shouldReturnAllFacilitiesAsList() {
+        createFacility("Facility 1", Facility.FacilityType.TENNIS, Facility.FacilityStatus.ACTIVE);
+        createFacility("Facility 2", Facility.FacilityType.PADEL, Facility.FacilityStatus.INACTIVE);
+        createFacility("Facility 3", Facility.FacilityType.FOOTBALL_7V7, Facility.FacilityStatus.ACTIVE);
+
+        ResponseEntity<List<FacilityResponseDTO>> response = restTemplate.exchange(
+                "/api/facilities",
+                HttpMethod.GET, null,
+                new ParameterizedTypeReference<List<FacilityResponseDTO>>() {});
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(3);
+    }
+
+    @Test
+    void searchPagedByStatusAndKeyword_shouldCombineFilters() {
+        createFacility("Sport Arena Active", Facility.FacilityType.TENNIS, Facility.FacilityStatus.ACTIVE);
+        createFacility("Sport Zone Inactive", Facility.FacilityType.TENNIS, Facility.FacilityStatus.INACTIVE);
+        createFacility("Other Active", Facility.FacilityType.PADEL, Facility.FacilityStatus.ACTIVE);
+
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                "/api/facilities?status=ACTIVE&q=Sport&page=0&size=10",
+                HttpMethod.GET, null,
+                new ParameterizedTypeReference<Map<String, Object>>() {});
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().get("totalElements")).isEqualTo(1);
+        List<Map<String, Object>> content = (List<Map<String, Object>>) response.getBody().get("content");
+        assertThat(content.get(0).get("name")).isEqualTo("Sport Arena Active");
+    }
+}

--- a/Resource Service/src/test/java/ba/nwt/resourceservice/integration/FacilityValidationIT.java
+++ b/Resource Service/src/test/java/ba/nwt/resourceservice/integration/FacilityValidationIT.java
@@ -1,0 +1,153 @@
+package ba.nwt.resourceservice.integration;
+
+import ba.nwt.resourceservice.dto.FacilityRequestDTO;
+import ba.nwt.resourceservice.model.Facility;
+import ba.nwt.resourceservice.repository.EquipmentRepository;
+import ba.nwt.resourceservice.repository.FacilityRepository;
+import ba.nwt.resourceservice.repository.PricingRuleRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for Facility input validation and business rules.
+ * Verifies that invalid requests are rejected before reaching the database.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class FacilityValidationIT {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private FacilityRepository facilityRepository;
+
+    @Autowired
+    private EquipmentRepository equipmentRepository;
+
+    @Autowired
+    private PricingRuleRepository pricingRuleRepository;
+
+    @BeforeEach
+    void cleanUp() {
+        pricingRuleRepository.deleteAll();
+        equipmentRepository.deleteAll();
+        facilityRepository.deleteAll();
+    }
+
+    @Test
+    void createFacility_shouldReturn400_whenWorkingHoursEndIsBeforeStart() {
+        FacilityRequestDTO request = FacilityRequestDTO.builder()
+                .ownerId(1L)
+                .name("Bad Hours Facility")
+                .type(Facility.FacilityType.TENNIS)
+                .capacity(4)
+                .basePricePerHour(new BigDecimal("30.00"))
+                .workingHoursStart(LocalTime.of(22, 0))
+                .workingHoursEnd(LocalTime.of(8, 0))
+                .build();
+
+        ResponseEntity<String> response = restTemplate.postForEntity("/api/facilities", request, String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(facilityRepository.count()).isZero();
+    }
+
+    @Test
+    void createFacility_shouldReturn400_whenNameIsMissing() {
+        FacilityRequestDTO request = FacilityRequestDTO.builder()
+                .ownerId(1L)
+                .type(Facility.FacilityType.TENNIS)
+                .capacity(4)
+                .basePricePerHour(new BigDecimal("30.00"))
+                .workingHoursStart(LocalTime.of(8, 0))
+                .workingHoursEnd(LocalTime.of(22, 0))
+                .build();
+
+        ResponseEntity<String> response = restTemplate.postForEntity("/api/facilities", request, String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(facilityRepository.count()).isZero();
+    }
+
+    @Test
+    void createFacility_shouldReturn400_whenPriceIsBelowMinimum() {
+        FacilityRequestDTO request = FacilityRequestDTO.builder()
+                .ownerId(1L)
+                .name("Free Facility")
+                .type(Facility.FacilityType.PADEL)
+                .capacity(4)
+                .basePricePerHour(new BigDecimal("0.00"))
+                .workingHoursStart(LocalTime.of(8, 0))
+                .workingHoursEnd(LocalTime.of(22, 0))
+                .build();
+
+        ResponseEntity<String> response = restTemplate.postForEntity("/api/facilities", request, String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(facilityRepository.count()).isZero();
+    }
+
+    @Test
+    void createFacility_shouldReturn400_whenOwnerIdIsMissing() {
+        FacilityRequestDTO request = FacilityRequestDTO.builder()
+                .name("Orphan Facility")
+                .type(Facility.FacilityType.TABLE_TENNIS)
+                .capacity(2)
+                .basePricePerHour(new BigDecimal("20.00"))
+                .workingHoursStart(LocalTime.of(8, 0))
+                .workingHoursEnd(LocalTime.of(22, 0))
+                .build();
+
+        ResponseEntity<String> response = restTemplate.postForEntity("/api/facilities", request, String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(facilityRepository.count()).isZero();
+    }
+
+    @Test
+    void createFacility_shouldReturn400_whenTypeIsMissing() {
+        FacilityRequestDTO request = FacilityRequestDTO.builder()
+                .ownerId(1L)
+                .name("Typeless Facility")
+                .capacity(4)
+                .basePricePerHour(new BigDecimal("25.00"))
+                .workingHoursStart(LocalTime.of(8, 0))
+                .workingHoursEnd(LocalTime.of(22, 0))
+                .build();
+
+        ResponseEntity<String> response = restTemplate.postForEntity("/api/facilities", request, String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(facilityRepository.count()).isZero();
+    }
+
+    @Test
+    void createFacility_shouldReturn400_whenCapacityIsZero() {
+        FacilityRequestDTO request = FacilityRequestDTO.builder()
+                .ownerId(1L)
+                .name("Zero Capacity Facility")
+                .type(Facility.FacilityType.TENNIS)
+                .capacity(0)
+                .basePricePerHour(new BigDecimal("30.00"))
+                .workingHoursStart(LocalTime.of(8, 0))
+                .workingHoursEnd(LocalTime.of(22, 0))
+                .build();
+
+        ResponseEntity<String> response = restTemplate.postForEntity("/api/facilities", request, String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(facilityRepository.count()).isZero();
+    }
+}

--- a/User Service/src/test/java/ba/nwt/userservice/integration/UserAchievementFlowIT.java
+++ b/User Service/src/test/java/ba/nwt/userservice/integration/UserAchievementFlowIT.java
@@ -1,0 +1,160 @@
+package ba.nwt.userservice.integration;
+
+import ba.nwt.userservice.dto.AchievementRequestDTO;
+import ba.nwt.userservice.dto.AchievementResponseDTO;
+import ba.nwt.userservice.dto.UserAchievementRequestDTO;
+import ba.nwt.userservice.dto.UserAchievementResponseDTO;
+import ba.nwt.userservice.dto.UserRequestDTO;
+import ba.nwt.userservice.dto.UserResponseDTO;
+import ba.nwt.userservice.model.Achievement;
+import ba.nwt.userservice.model.User;
+import ba.nwt.userservice.repository.AchievementRepository;
+import ba.nwt.userservice.repository.UserAchievementRepository;
+import ba.nwt.userservice.repository.UserLoyaltyRepository;
+import ba.nwt.userservice.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Flow: dodjela achievementa korisniku.
+ * Testira kompletan tok: kreiranje korisnika + achievementa,
+ * dodjela, provjera vidljivosti u profilu, brisanje dodjele.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class UserAchievementFlowIT {
+
+    @Autowired private TestRestTemplate restTemplate;
+    @Autowired private UserRepository userRepository;
+    @Autowired private UserAchievementRepository userAchievementRepository;
+    @Autowired private UserLoyaltyRepository userLoyaltyRepository;
+    @Autowired private AchievementRepository achievementRepository;
+
+    @BeforeEach
+    void cleanUp() {
+        userAchievementRepository.deleteAll();
+        userLoyaltyRepository.deleteAll();
+        userRepository.deleteAll();
+        achievementRepository.deleteAll();
+    }
+
+    private UserResponseDTO createUser(String username, String email) {
+        return restTemplate.postForObject("/api/users",
+                UserRequestDTO.builder()
+                        .username(username).email(email)
+                        .password("password123").role(User.Role.USER).build(),
+                UserResponseDTO.class);
+    }
+
+    private AchievementResponseDTO createAchievement(String name) {
+        return restTemplate.postForObject("/api/achievements",
+                AchievementRequestDTO.builder()
+                        .name(name)
+                        .category(Achievement.AchievementCategory.MILESTONE)
+                        .build(),
+                AchievementResponseDTO.class);
+    }
+
+    private UserAchievementResponseDTO assignAchievement(Long userId, Long achievementId) {
+        return restTemplate.postForObject("/api/user-achievements",
+                UserAchievementRequestDTO.builder()
+                        .userId(userId).achievementId(achievementId).build(),
+                UserAchievementResponseDTO.class);
+    }
+
+    private List<UserAchievementResponseDTO> getAchievementsForUser(Long userId) {
+        ResponseEntity<List<UserAchievementResponseDTO>> resp = restTemplate.exchange(
+                "/api/user-achievements/user/" + userId, HttpMethod.GET, null,
+                new ParameterizedTypeReference<List<UserAchievementResponseDTO>>() {});
+        return resp.getBody();
+    }
+
+    @Test
+    void assignAchievement_shouldAppearInUsersAchievementList() {
+        UserResponseDTO user = createUser("ivan", "ivan@example.com");
+        AchievementResponseDTO ach = createAchievement("Prva rezervacija");
+
+        assignAchievement(user.getId(), ach.getId());
+
+        List<UserAchievementResponseDTO> achievements = getAchievementsForUser(user.getId());
+
+        assertThat(achievements).hasSize(1);
+        assertThat(achievements.get(0).getUserId()).isEqualTo(user.getId());
+        assertThat(achievements.get(0).getAchievementId()).isEqualTo(ach.getId());
+        assertThat(achievements.get(0).getAchievementName()).isEqualTo("Prva rezervacija");
+        assertThat(achievements.get(0).getUnlockedAt()).isNotNull();
+    }
+
+    @Test
+    void assignMultipleAchievements_allVisibleForUser() {
+        UserResponseDTO user = createUser("marko", "marko@example.com");
+        AchievementResponseDTO ach1 = createAchievement("10 rezervacija");
+        AchievementResponseDTO ach2 = createAchievement("Redovni igrač");
+        AchievementResponseDTO ach3 = createAchievement("Oprema spremna");
+
+        assignAchievement(user.getId(), ach1.getId());
+        assignAchievement(user.getId(), ach2.getId());
+        assignAchievement(user.getId(), ach3.getId());
+
+        List<UserAchievementResponseDTO> achievements = getAchievementsForUser(user.getId());
+
+        assertThat(achievements).hasSize(3);
+        assertThat(achievements).extracting(UserAchievementResponseDTO::getAchievementName)
+                .containsExactlyInAnyOrder("10 rezervacija", "Redovni igrač", "Oprema spremna");
+    }
+
+    @Test
+    void deleteAchievementAssignment_shouldDisappearFromUserProfile() {
+        UserResponseDTO user = createUser("ana", "ana@example.com");
+        AchievementResponseDTO ach = createAchievement("Bonus achievement");
+
+        UserAchievementResponseDTO assignment = assignAchievement(user.getId(), ach.getId());
+        assertThat(getAchievementsForUser(user.getId())).hasSize(1);
+
+        ResponseEntity<Void> deleteResp = restTemplate.exchange(
+                "/api/user-achievements/" + assignment.getId(), HttpMethod.DELETE, null, Void.class);
+        assertThat(deleteResp.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+
+        assertThat(getAchievementsForUser(user.getId())).isEmpty();
+        assertThat(userAchievementRepository.count()).isZero();
+    }
+
+    @Test
+    void achievementsArePerUser_twoUsersHaveSeparateAchievements() {
+        UserResponseDTO user1 = createUser("petra", "petra@example.com");
+        UserResponseDTO user2 = createUser("luka",  "luka@example.com");
+        AchievementResponseDTO ach = createAchievement("Shared achievement");
+
+        assignAchievement(user1.getId(), ach.getId());
+        assignAchievement(user2.getId(), ach.getId());
+
+        assertThat(getAchievementsForUser(user1.getId())).hasSize(1);
+        assertThat(getAchievementsForUser(user2.getId())).hasSize(1);
+        // Svaki ima svoju instancu dodjele
+        assertThat(userAchievementRepository.count()).isEqualTo(2);
+    }
+
+    @Test
+    void assignToNonexistentUser_shouldReturn404() {
+        AchievementResponseDTO ach = createAchievement("Phantom achievement");
+
+        ResponseEntity<String> resp = restTemplate.postForEntity("/api/user-achievements",
+                UserAchievementRequestDTO.builder().userId(99999L).achievementId(ach.getId()).build(),
+                String.class);
+
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(userAchievementRepository.count()).isZero();
+    }
+}

--- a/User Service/src/test/java/ba/nwt/userservice/integration/UserCrudIT.java
+++ b/User Service/src/test/java/ba/nwt/userservice/integration/UserCrudIT.java
@@ -1,0 +1,162 @@
+package ba.nwt.userservice.integration;
+
+import ba.nwt.userservice.dto.UserRequestDTO;
+import ba.nwt.userservice.dto.UserResponseDTO;
+import ba.nwt.userservice.model.User;
+import ba.nwt.userservice.repository.UserAchievementRepository;
+import ba.nwt.userservice.repository.UserLoyaltyRepository;
+import ba.nwt.userservice.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for User CRUD operations.
+ * Full Spring context with H2 in-memory database — no mocks.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class UserCrudIT {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserAchievementRepository userAchievementRepository;
+
+    @Autowired
+    private UserLoyaltyRepository userLoyaltyRepository;
+
+    @BeforeEach
+    void cleanUp() {
+        userAchievementRepository.deleteAll();
+        userLoyaltyRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    private UserRequestDTO buildRequest(String username, String email) {
+        return UserRequestDTO.builder()
+                .username(username)
+                .email(email)
+                .password("password123")
+                .role(User.Role.USER)
+                .phone("+38762111222")
+                .build();
+    }
+
+    @Test
+    void createUser_shouldReturn201AndPersistToDatabase() {
+        UserRequestDTO request = buildRequest("johndoe", "john@example.com");
+
+        ResponseEntity<UserResponseDTO> response =
+                restTemplate.postForEntity("/api/users", request, UserResponseDTO.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getId()).isPositive();
+        assertThat(response.getBody().getUsername()).isEqualTo("johndoe");
+        assertThat(response.getBody().getEmail()).isEqualTo("john@example.com");
+        assertThat(response.getBody().getRole()).isEqualTo(User.Role.USER);
+        assertThat(userRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    void getUserById_shouldReturn200WithPersistedData() {
+        UserResponseDTO created =
+                restTemplate.postForObject("/api/users", buildRequest("janedoe", "jane@example.com"), UserResponseDTO.class);
+
+        ResponseEntity<UserResponseDTO> response =
+                restTemplate.getForEntity("/api/users/" + created.getId(), UserResponseDTO.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getUsername()).isEqualTo("janedoe");
+        assertThat(response.getBody().getEmail()).isEqualTo("jane@example.com");
+    }
+
+    @Test
+    void getUserByUsername_shouldReturn200WithMatchingUser() {
+        restTemplate.postForObject("/api/users", buildRequest("alice", "alice@example.com"), UserResponseDTO.class);
+
+        ResponseEntity<UserResponseDTO> response =
+                restTemplate.getForEntity("/api/users/username/alice", UserResponseDTO.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getUsername()).isEqualTo("alice");
+        assertThat(response.getBody().getEmail()).isEqualTo("alice@example.com");
+    }
+
+    @Test
+    void updateUser_shouldReturn200WithModifiedData() {
+        UserResponseDTO created =
+                restTemplate.postForObject("/api/users", buildRequest("original", "orig@example.com"), UserResponseDTO.class);
+
+        UserRequestDTO updateRequest = UserRequestDTO.builder()
+                .username("updated")
+                .email("updated@example.com")
+                .password("newpassword123")
+                .role(User.Role.OWNER)
+                .build();
+
+        ResponseEntity<UserResponseDTO> response = restTemplate.exchange(
+                "/api/users/" + created.getId(),
+                HttpMethod.PUT,
+                new HttpEntity<>(updateRequest),
+                UserResponseDTO.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getUsername()).isEqualTo("updated");
+        assertThat(response.getBody().getEmail()).isEqualTo("updated@example.com");
+        assertThat(response.getBody().getRole()).isEqualTo(User.Role.OWNER);
+    }
+
+    @Test
+    void deleteUser_shouldReturn204AndSubsequentGetReturns404() {
+        UserResponseDTO created =
+                restTemplate.postForObject("/api/users", buildRequest("todelete", "delete@example.com"), UserResponseDTO.class);
+
+        ResponseEntity<Void> deleteResponse = restTemplate.exchange(
+                "/api/users/" + created.getId(), HttpMethod.DELETE, null, Void.class);
+
+        assertThat(deleteResponse.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+
+        ResponseEntity<String> getResponse =
+                restTemplate.getForEntity("/api/users/" + created.getId(), String.class);
+        assertThat(getResponse.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(userRepository.existsById(created.getId())).isFalse();
+    }
+
+    @Test
+    void getUser_shouldReturn404_whenIdDoesNotExist() {
+        ResponseEntity<String> response = restTemplate.getForEntity("/api/users/999999", String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    void getAllUsers_shouldReturnAllPersistedUsers() {
+        restTemplate.postForObject("/api/users", buildRequest("user1", "u1@example.com"), UserResponseDTO.class);
+        restTemplate.postForObject("/api/users", buildRequest("user2", "u2@example.com"), UserResponseDTO.class);
+
+        ResponseEntity<List<UserResponseDTO>> response = restTemplate.exchange(
+                "/api/users", HttpMethod.GET, null,
+                new ParameterizedTypeReference<List<UserResponseDTO>>() {});
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(2);
+    }
+}

--- a/User Service/src/test/java/ba/nwt/userservice/integration/UserLoyaltyTierUpgradeIT.java
+++ b/User Service/src/test/java/ba/nwt/userservice/integration/UserLoyaltyTierUpgradeIT.java
@@ -1,0 +1,137 @@
+package ba.nwt.userservice.integration;
+
+import ba.nwt.userservice.dto.UserLoyaltyResponseDTO;
+import ba.nwt.userservice.dto.UserRequestDTO;
+import ba.nwt.userservice.dto.UserResponseDTO;
+import ba.nwt.userservice.model.User;
+import ba.nwt.userservice.model.UserLoyalty;
+import ba.nwt.userservice.repository.AchievementRepository;
+import ba.nwt.userservice.repository.UserAchievementRepository;
+import ba.nwt.userservice.repository.UserLoyaltyRepository;
+import ba.nwt.userservice.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Flow: loyalty sistem — dodavanje bodova i automatski tier upgrade.
+ * Testira prelaz BRONZE → SILVER → GOLD i auto-kreiranje tier achievementa.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class UserLoyaltyTierUpgradeIT {
+
+    @Autowired private TestRestTemplate restTemplate;
+    @Autowired private UserRepository userRepository;
+    @Autowired private UserLoyaltyRepository userLoyaltyRepository;
+    @Autowired private UserAchievementRepository userAchievementRepository;
+    @Autowired private AchievementRepository achievementRepository;
+
+    @BeforeEach
+    void cleanUp() {
+        userAchievementRepository.deleteAll();
+        userLoyaltyRepository.deleteAll();
+        userRepository.deleteAll();
+        achievementRepository.deleteAll();
+    }
+
+    /** Kreira korisnika i seed-uje loyalty zapis direktno u repo (nema HTTP endpoint za create). */
+    private User setupUserWithLoyalty(String username, int initialPoints, UserLoyalty.LoyaltyTier tier) {
+        UserResponseDTO dto = restTemplate.postForObject("/api/users",
+                UserRequestDTO.builder()
+                        .username(username).email(username + "@test.com")
+                        .password("password123").role(User.Role.USER).build(),
+                UserResponseDTO.class);
+
+        User userEntity = userRepository.findById(dto.getId()).orElseThrow();
+        userLoyaltyRepository.save(UserLoyalty.builder()
+                .user(userEntity).totalPoints(initialPoints).tier(tier).build());
+        return userEntity;
+    }
+
+    private UserLoyaltyResponseDTO addPoints(Long userId, int points) {
+        String url = UriComponentsBuilder.fromPath("/api/loyalty/user/{id}/add-points")
+                .queryParam("points", points)
+                .buildAndExpand(userId).toUriString();
+        return restTemplate.exchange(url,
+                org.springframework.http.HttpMethod.PATCH, null,
+                UserLoyaltyResponseDTO.class).getBody();
+    }
+
+    @Test
+    void addPoints_shouldIncreaseTotalPoints() {
+        User user = setupUserWithLoyalty("player1", 100, UserLoyalty.LoyaltyTier.BRONZE);
+
+        UserLoyaltyResponseDTO result = addPoints(user.getId(), 50);
+
+        assertThat(result.getTotalPoints()).isEqualTo(150);
+        assertThat(result.getTier()).isEqualTo(UserLoyalty.LoyaltyTier.BRONZE);
+    }
+
+    @Test
+    void crossingBronzeToSilverThreshold_shouldUpgradeTierAutomatically() {
+        // 480 BRONZE + 30 = 510 → SILVER (threshold 500)
+        User user = setupUserWithLoyalty("player2", 480, UserLoyalty.LoyaltyTier.BRONZE);
+
+        UserLoyaltyResponseDTO result = addPoints(user.getId(), 30);
+
+        assertThat(result.getTotalPoints()).isEqualTo(510);
+        assertThat(result.getTier()).isEqualTo(UserLoyalty.LoyaltyTier.SILVER);
+        assertThat(result.getTierAchievedAt()).isNotNull();
+    }
+
+    @Test
+    void crossingSilverToGoldThreshold_shouldUpgradeTierToGold() {
+        // 1980 SILVER + 50 = 2030 → GOLD (threshold 2000)
+        User user = setupUserWithLoyalty("player3", 1980, UserLoyalty.LoyaltyTier.SILVER);
+
+        UserLoyaltyResponseDTO result = addPoints(user.getId(), 50);
+
+        assertThat(result.getTotalPoints()).isEqualTo(2030);
+        assertThat(result.getTier()).isEqualTo(UserLoyalty.LoyaltyTier.GOLD);
+    }
+
+    @Test
+    void tierUpgrade_shouldAutoAssignTierAchievementToUser() {
+        // Tier upgrade automatski dodijeli achievement "Tier reached: SILVER"
+        User user = setupUserWithLoyalty("player4", 490, UserLoyalty.LoyaltyTier.BRONZE);
+
+        addPoints(user.getId(), 20); // 490 + 20 = 510 → SILVER upgrade
+
+        // Provjeri da je "Tier reached: SILVER" achievement kreiran u bazi
+        assertThat(achievementRepository.findAll())
+                .anyMatch(a -> a.getName().equals("Tier reached: SILVER"));
+
+        // Provjeri da je korisniku dodijeljen barem jedan tier achievement
+        // (via HTTP endpoint koji dohvaća achievements za korisnika)
+        ResponseEntity<java.util.List<ba.nwt.userservice.dto.UserAchievementResponseDTO>> resp =
+                restTemplate.exchange("/api/user-achievements/user/" + user.getId(),
+                        org.springframework.http.HttpMethod.GET, null,
+                        new org.springframework.core.ParameterizedTypeReference<
+                                java.util.List<ba.nwt.userservice.dto.UserAchievementResponseDTO>>() {});
+        assertThat(resp.getBody()).isNotEmpty();
+        assertThat(resp.getBody()).anyMatch(ua -> ua.getAchievementName().contains("SILVER"));
+    }
+
+    @Test
+    void addingZeroOrNegativePoints_shouldReturn400() {
+        User user = setupUserWithLoyalty("player5", 100, UserLoyalty.LoyaltyTier.BRONZE);
+
+        String urlZero = UriComponentsBuilder.fromPath("/api/loyalty/user/{id}/add-points")
+                .queryParam("points", 0).buildAndExpand(user.getId()).toUriString();
+        ResponseEntity<String> zeroResp = restTemplate.exchange(
+                urlZero, org.springframework.http.HttpMethod.PATCH, null, String.class);
+        assertThat(zeroResp.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+
+        // Bodovi nisu promijenjeni
+        assertThat(userLoyaltyRepository.findByUserId(user.getId()).get().getTotalPoints()).isEqualTo(100);
+    }
+}

--- a/User Service/src/test/java/ba/nwt/userservice/integration/UserSearchIT.java
+++ b/User Service/src/test/java/ba/nwt/userservice/integration/UserSearchIT.java
@@ -1,0 +1,146 @@
+package ba.nwt.userservice.integration;
+
+import ba.nwt.userservice.dto.UserRequestDTO;
+import ba.nwt.userservice.dto.UserResponseDTO;
+import ba.nwt.userservice.model.User;
+import ba.nwt.userservice.repository.UserAchievementRepository;
+import ba.nwt.userservice.repository.UserLoyaltyRepository;
+import ba.nwt.userservice.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for User paginated search endpoint.
+ * Validates filtering by role and keyword, and pagination behaviour.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class UserSearchIT {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserAchievementRepository userAchievementRepository;
+
+    @Autowired
+    private UserLoyaltyRepository userLoyaltyRepository;
+
+    @BeforeEach
+    void cleanUp() {
+        userAchievementRepository.deleteAll();
+        userLoyaltyRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    private void createUser(String username, String email, User.Role role) {
+        restTemplate.postForObject("/api/users",
+                UserRequestDTO.builder()
+                        .username(username)
+                        .email(email)
+                        .password("password123")
+                        .role(role)
+                        .build(),
+                UserResponseDTO.class);
+    }
+
+    @Test
+    void searchByRole_shouldReturnOnlyUsersWithMatchingRole() {
+        createUser("user1", "user1@example.com", User.Role.USER);
+        createUser("user2", "user2@example.com", User.Role.USER);
+        createUser("owner1", "owner1@example.com", User.Role.OWNER);
+
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                "/api/users/search?role=USER&page=0&size=10",
+                HttpMethod.GET, null,
+                new ParameterizedTypeReference<Map<String, Object>>() {});
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        List<?> content = (List<?>) response.getBody().get("content");
+        assertThat(content).hasSize(2);
+        assertThat(response.getBody().get("totalElements")).isEqualTo(2);
+    }
+
+    @Test
+    void searchByKeyword_shouldMatchUsernameAndEmail() {
+        createUser("alice", "alice@sport.com", User.Role.USER);
+        createUser("bob", "bob@sport.com", User.Role.USER);
+        createUser("charlie", "charlie@other.com", User.Role.OWNER);
+
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                "/api/users/search?q=sport&page=0&size=10",
+                HttpMethod.GET, null,
+                new ParameterizedTypeReference<Map<String, Object>>() {});
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        List<?> content = (List<?>) response.getBody().get("content");
+        assertThat(content).hasSize(2);
+        assertThat(response.getBody().get("totalElements")).isEqualTo(2);
+    }
+
+    @Test
+    void searchWithPaging_shouldRespectPageSizeAndReportCorrectTotals() {
+        for (int i = 1; i <= 5; i++) {
+            createUser("player" + i, "player" + i + "@example.com", User.Role.USER);
+        }
+
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                "/api/users/search?role=USER&page=0&size=3",
+                HttpMethod.GET, null,
+                new ParameterizedTypeReference<Map<String, Object>>() {});
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().get("totalElements")).isEqualTo(5);
+        assertThat(response.getBody().get("totalPages")).isEqualTo(2);
+        List<?> content = (List<?>) response.getBody().get("content");
+        assertThat(content).hasSize(3);
+    }
+
+    @Test
+    void searchByRoleAndKeyword_shouldIntersectBothFilters() {
+        createUser("alice", "alice@example.com", User.Role.USER);
+        createUser("alicia", "alicia@example.com", User.Role.OWNER);
+        createUser("bob", "bob@example.com", User.Role.USER);
+
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                "/api/users/search?role=USER&q=alice&page=0&size=10",
+                HttpMethod.GET, null,
+                new ParameterizedTypeReference<Map<String, Object>>() {});
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().get("totalElements")).isEqualTo(1);
+        List<Map<String, Object>> content = (List<Map<String, Object>>) response.getBody().get("content");
+        assertThat(content.get(0).get("username")).isEqualTo("alice");
+    }
+
+    @Test
+    void searchWithEmptyResult_shouldReturnZeroElements_whenNoUsersMatchRole() {
+        createUser("onlyUser", "only@example.com", User.Role.USER);
+
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                "/api/users/search?role=ADMIN&page=0&size=10",
+                HttpMethod.GET, null,
+                new ParameterizedTypeReference<Map<String, Object>>() {});
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().get("totalElements")).isEqualTo(0);
+        List<?> content = (List<?>) response.getBody().get("content");
+        assertThat(content).isEmpty();
+    }
+}

--- a/User Service/src/test/java/ba/nwt/userservice/integration/UserValidationIT.java
+++ b/User Service/src/test/java/ba/nwt/userservice/integration/UserValidationIT.java
@@ -1,0 +1,161 @@
+package ba.nwt.userservice.integration;
+
+import ba.nwt.userservice.dto.UserRequestDTO;
+import ba.nwt.userservice.dto.UserResponseDTO;
+import ba.nwt.userservice.model.User;
+import ba.nwt.userservice.repository.UserAchievementRepository;
+import ba.nwt.userservice.repository.UserLoyaltyRepository;
+import ba.nwt.userservice.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for User input validation and uniqueness constraints.
+ * Verifies that invalid or duplicate data is rejected at the HTTP layer.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class UserValidationIT {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserAchievementRepository userAchievementRepository;
+
+    @Autowired
+    private UserLoyaltyRepository userLoyaltyRepository;
+
+    @BeforeEach
+    void cleanUp() {
+        userAchievementRepository.deleteAll();
+        userLoyaltyRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    private UserRequestDTO validRequest() {
+        return UserRequestDTO.builder()
+                .username("validuser")
+                .email("valid@example.com")
+                .password("password123")
+                .role(User.Role.USER)
+                .build();
+    }
+
+    @Test
+    void createUser_shouldReturn400_whenUsernameIsTooShort() {
+        UserRequestDTO request = validRequest();
+        request.setUsername("ab");
+
+        ResponseEntity<String> response = restTemplate.postForEntity("/api/users", request, String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(userRepository.count()).isZero();
+    }
+
+    @Test
+    void createUser_shouldReturn400_whenEmailIsInvalid() {
+        UserRequestDTO request = validRequest();
+        request.setEmail("not-an-email");
+
+        ResponseEntity<String> response = restTemplate.postForEntity("/api/users", request, String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(userRepository.count()).isZero();
+    }
+
+    @Test
+    void createUser_shouldReturn400_whenPasswordIsTooShort() {
+        UserRequestDTO request = validRequest();
+        request.setPassword("123");
+
+        ResponseEntity<String> response = restTemplate.postForEntity("/api/users", request, String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(userRepository.count()).isZero();
+    }
+
+    @Test
+    void createUser_shouldReturn400_whenRoleIsMissing() {
+        UserRequestDTO request = UserRequestDTO.builder()
+                .username("validuser")
+                .email("valid@example.com")
+                .password("password123")
+                .role(null)
+                .build();
+
+        ResponseEntity<String> response = restTemplate.postForEntity("/api/users", request, String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void createUser_shouldReturn400_whenUsernameIsDuplicate() {
+        UserRequestDTO first = UserRequestDTO.builder()
+                .username("duplicate")
+                .email("first@example.com")
+                .password("password123")
+                .role(User.Role.USER)
+                .build();
+        restTemplate.postForObject("/api/users", first, UserResponseDTO.class);
+
+        UserRequestDTO second = UserRequestDTO.builder()
+                .username("duplicate")
+                .email("second@example.com")
+                .password("password123")
+                .role(User.Role.USER)
+                .build();
+
+        ResponseEntity<String> response = restTemplate.postForEntity("/api/users", second, String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(userRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    void createUser_shouldReturn400_whenEmailIsDuplicate() {
+        UserRequestDTO first = UserRequestDTO.builder()
+                .username("user1")
+                .email("shared@example.com")
+                .password("password123")
+                .role(User.Role.USER)
+                .build();
+        restTemplate.postForObject("/api/users", first, UserResponseDTO.class);
+
+        UserRequestDTO second = UserRequestDTO.builder()
+                .username("user2")
+                .email("shared@example.com")
+                .password("password123")
+                .role(User.Role.USER)
+                .build();
+
+        ResponseEntity<String> response = restTemplate.postForEntity("/api/users", second, String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(userRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    void updateUser_shouldReturn404_whenUserDoesNotExist() {
+        UserRequestDTO request = validRequest();
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                "/api/users/999999",
+                org.springframework.http.HttpMethod.PUT,
+                new org.springframework.http.HttpEntity<>(request),
+                String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+}

--- a/User Service/src/test/resources/application-test.properties
+++ b/User Service/src/test/resources/application-test.properties
@@ -1,4 +1,6 @@
 # ── Test Configuration — H2 In-Memory ──
+server.port=0
+
 spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false;MODE=MYSQL
 spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.username=sa
@@ -12,6 +14,20 @@ spring.jpa.properties.hibernate.generate_statistics=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
 
 spring.main.allow-bean-definition-overriding=true
+
+# ── Disable external services ──
+eureka.client.enabled=false
+eureka.client.register-with-eureka=false
+eureka.client.fetch-registry=false
+spring.cloud.discovery.enabled=false
+spring.cloud.config.enabled=false
+spring.cloud.config.import-check.enabled=false
+spring.config.import=optional:configserver:
+
+# ── JWT (test-only secret) ──
+jwt.secret=TestSecretKeyForIntegrationTestsOnlySportsCenterSystem2026
+jwt.expiration=86400
+jwt.refresh.expiration=604800
 
 
 


### PR DESCRIPTION
Added integration tests for all four microservices using H2 in-memory database

  Adds 103 integration tests across 16 test classes covering User, Resource, Booking, and Payment services. Tests use @SpringBootTest with RANDOM_PORT and TestRestTemplate — full HTTP stack with a real Spring context and H2 in-memory database,
  no mocking of business logic.

  Two categories of tests:
  - CRUD/Validation: endpoint-level tests for persistence, error responses, and input validation
  - Flow tests: multi-step business scenarios including booking conflict detection, status lifecycle (PENDING → CONFIRMED → COMPLETED), recurring booking atomicity, payment refund with notification creation, loyalty tier upgrade with
  auto-achievement assignment, and facility-equipment linking

  Test infrastructure: each service has an updated application-test.properties disabling Eureka, Config Server, and RabbitMQ (Booking/Payment), with per-service named H2 databases to avoid collisions.