### PR TITLE
feat: LV5 synchronous communication 

### DIFF
--- a/Booking Service/src/main/java/ba/nwt/bookingservice/client/dto/PaymentCreateView.java
+++ b/Booking Service/src/main/java/ba/nwt/bookingservice/client/dto/PaymentCreateView.java
@@ -8,6 +8,7 @@ import java.math.BigDecimal;
 @Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class PaymentCreateView {
+    private Long userId;
     private Long bookingId;
     private Long rentalId;
     private BigDecimal amount;

--- a/Booking Service/src/main/java/ba/nwt/bookingservice/service/BookingService.java
+++ b/Booking Service/src/main/java/ba/nwt/bookingservice/service/BookingService.java
@@ -311,6 +311,7 @@ public class BookingService {
         PaymentView payment;
         try {
             payment = paymentServiceClient.createPayment(PaymentCreateView.builder()
+                    .userId(dto.getUserId())
                     .bookingId(booking.getId())
                     .amount(authoritativePrice)
                     .paymentMethod(paymentMethod == null ? "CREDIT_CARD" : paymentMethod)

--- a/Booking Service/src/test/java/ba/nwt/bookingservice/integration/BookingFeignWireMockIT.java
+++ b/Booking Service/src/test/java/ba/nwt/bookingservice/integration/BookingFeignWireMockIT.java
@@ -1,0 +1,252 @@
+package ba.nwt.bookingservice.integration;
+
+import ba.nwt.bookingservice.dto.BookingRequestDTO;
+import ba.nwt.bookingservice.dto.BookingResponseDTO;
+import ba.nwt.bookingservice.model.Booking;
+import ba.nwt.bookingservice.repository.BookingRepository;
+import ba.nwt.bookingservice.repository.BookingUserRepository;
+import ba.nwt.bookingservice.repository.EquipmentRentalRepository;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * WireMock integration tests for the synchronous Feign-based orchestration in
+ * POST /api/bookings/orchestrated (BookingService#createOrchestrated).
+ *
+ * Unlike the unit-level mocks in BookingServiceZ5OrchestrationTest, these tests
+ * exercise Feign's actual HTTP layer: URL construction, serialisation, deserialisation,
+ * and the TypedErrorDecoder's HTTP-status-to-exception mapping.
+ *
+ * Feign clients are redirected to a local WireMock server via
+ * spring.cloud.openfeign.client.config.<name>.url — Eureka is still disabled.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class BookingFeignWireMockIT {
+
+    // Single WireMock instance shared by all three downstream services.
+    // Path prefixes (/api/facilities, /api/pricing-rules, /api/payments, /api/loyalty) are unique.
+    @RegisterExtension
+    static WireMockExtension wm = WireMockExtension.newInstance()
+            .options(wireMockConfig().dynamicPort())
+            .build();
+
+    // Redirect all three Feign clients to the WireMock server before the Spring context starts.
+    @DynamicPropertySource
+    static void overrideFeignUrls(DynamicPropertyRegistry registry) {
+        registry.add("spring.cloud.openfeign.client.config.resource-service.url",
+                () -> "http://localhost:" + wm.getPort());
+        registry.add("spring.cloud.openfeign.client.config.payment-service.url",
+                () -> "http://localhost:" + wm.getPort());
+        registry.add("spring.cloud.openfeign.client.config.user-service.url",
+                () -> "http://localhost:" + wm.getPort());
+    }
+
+    @MockBean
+    private RabbitTemplate rabbitTemplate;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private BookingRepository bookingRepository;
+
+    @Autowired
+    private BookingUserRepository bookingUserRepository;
+
+    @Autowired
+    private EquipmentRentalRepository equipmentRentalRepository;
+
+    @BeforeEach
+    void cleanUp() {
+        bookingUserRepository.deleteAll();
+        equipmentRentalRepository.deleteAll();
+        bookingRepository.deleteAll();
+        wm.resetAll();
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private BookingRequestDTO buildRequest() {
+        LocalDateTime start = LocalDateTime.now().plusDays(1)
+                .withHour(10).withMinute(0).withSecond(0).withNano(0);
+        return BookingRequestDTO.builder()
+                .userId(1L)
+                .facilityId(1L)
+                .startTime(start)
+                .endTime(start.plusHours(2))
+                .totalPrice(new BigDecimal("1.00"))
+                .build();
+    }
+
+    private void stubAllServicesOk() {
+        wm.stubFor(get(urlPathEqualTo("/api/facilities/1"))
+                .willReturn(okJson(
+                        "{\"id\":1,\"status\":\"ACTIVE\",\"name\":\"Tennis Court 1\",\"type\":\"TENNIS\"}")));
+
+        wm.stubFor(get(urlPathEqualTo("/api/pricing-rules/calculate"))
+                .willReturn(okJson(
+                        "{\"facilityId\":1,\"totalPrice\":100.00,\"multiplier\":1.0,\"hours\":2.0}")));
+
+        wm.stubFor(post(urlPathEqualTo("/api/payments"))
+                .willReturn(aResponse()
+                        .withStatus(201)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"id\":1,\"bookingId\":1,\"amount\":100.00," +
+                                  "\"status\":\"PAID\",\"transactionId\":\"TXN-WIREMOCK-001\"}")));
+
+        wm.stubFor(patch(urlPathMatching("/api/loyalty/user/\\d+/add-points"))
+                .willReturn(ok()));
+    }
+
+    // ── Tests ────────────────────────────────────────────────────────────────
+
+    /**
+     * All downstream services respond successfully.
+     * Verifies that Feign actually fires all four HTTP requests and
+     * that the booking ends up CONFIRMED in the database.
+     */
+    @Test
+    void happyPath_allServicesOk_returns201AndBookingIsConfirmed() {
+        stubAllServicesOk();
+
+        ResponseEntity<BookingResponseDTO> response = restTemplate.postForEntity(
+                "/api/bookings/orchestrated?paymentMethod=CREDIT_CARD",
+                buildRequest(),
+                BookingResponseDTO.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+
+        List<Booking> bookings = bookingRepository.findAll();
+        assertThat(bookings).hasSize(1);
+        assertThat(bookings.get(0).getStatus()).isEqualTo(Booking.BookingStatus.CONFIRMED);
+
+        // Feign really made all 3 critical HTTP calls — this is what @MockBean tests cannot verify.
+        wm.verify(getRequestedFor(urlPathEqualTo("/api/facilities/1")));
+        wm.verify(getRequestedFor(urlPathEqualTo("/api/pricing-rules/calculate")));
+        wm.verify(postRequestedFor(urlPathEqualTo("/api/payments")));
+        // Loyalty is best-effort: UserServiceClientFallback swallows failures silently.
+        // The userServiceDown_loyaltyBestEffort_bookingStillConfirmed test covers that semantic.
+    }
+
+    /**
+     * Resource Service returns 503.
+     * TypedErrorDecoder maps it to DownstreamUnavailableException → GlobalExceptionHandler → 503.
+     * The booking must NOT be persisted (failure happens before any DB write).
+     */
+    @Test
+    void resourceServiceDown_returns503_noBookingPersisted() {
+        wm.stubFor(get(urlPathEqualTo("/api/facilities/1"))
+                .willReturn(aResponse().withStatus(503)));
+
+        ResponseEntity<String> response = restTemplate.postForEntity(
+                "/api/bookings/orchestrated?paymentMethod=CREDIT_CARD",
+                buildRequest(),
+                String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        assertThat(bookingRepository.findAll()).isEmpty();
+    }
+
+    /**
+     * Resource Service returns an inactive facility (status != ACTIVE).
+     * createOrchestrated throws IllegalArgumentException → GlobalExceptionHandler → 400.
+     * No booking persisted.
+     */
+    @Test
+    void facilityInactive_returns400_noBookingPersisted() {
+        wm.stubFor(get(urlPathEqualTo("/api/facilities/1"))
+                .willReturn(okJson(
+                        "{\"id\":1,\"status\":\"INACTIVE\",\"name\":\"Court 1\",\"type\":\"TENNIS\"}")));
+
+        ResponseEntity<String> response = restTemplate.postForEntity(
+                "/api/bookings/orchestrated?paymentMethod=CREDIT_CARD",
+                buildRequest(),
+                String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(bookingRepository.findAll()).isEmpty();
+    }
+
+    /**
+     * Payment Service returns 503 after the booking has been saved as PENDING.
+     * DownstreamUnavailableException is a RuntimeException — @Transactional rolls back
+     * the entire unit of work, so nothing survives in the database.
+     * The caller receives 503.
+     */
+    @Test
+    void paymentServiceDown_returns503_transactionRolledBack() {
+        wm.stubFor(get(urlPathEqualTo("/api/facilities/1"))
+                .willReturn(okJson(
+                        "{\"id\":1,\"status\":\"ACTIVE\",\"name\":\"Court 1\",\"type\":\"TENNIS\"}")));
+        wm.stubFor(get(urlPathEqualTo("/api/pricing-rules/calculate"))
+                .willReturn(okJson(
+                        "{\"facilityId\":1,\"totalPrice\":100.00}")));
+        wm.stubFor(post(urlPathEqualTo("/api/payments"))
+                .willReturn(aResponse().withStatus(503)));
+
+        ResponseEntity<String> response = restTemplate.postForEntity(
+                "/api/bookings/orchestrated?paymentMethod=CREDIT_CARD",
+                buildRequest(),
+                String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        // @Transactional rolls back when DownstreamUnavailableException (RuntimeException) escapes.
+        assertThat(bookingRepository.findAll()).isEmpty();
+    }
+
+    /**
+     * User Service returns 503 while crediting loyalty points.
+     * The fallback swallows the exception — booking must still be CONFIRMED.
+     * This is the "best-effort" semantic: loyalty failure must never cancel a booking.
+     */
+    @Test
+    void userServiceDown_loyaltyBestEffort_bookingStillConfirmed() {
+        wm.stubFor(get(urlPathEqualTo("/api/facilities/1"))
+                .willReturn(okJson(
+                        "{\"id\":1,\"status\":\"ACTIVE\",\"name\":\"Court 1\",\"type\":\"TENNIS\"}")));
+        wm.stubFor(get(urlPathEqualTo("/api/pricing-rules/calculate"))
+                .willReturn(okJson(
+                        "{\"facilityId\":1,\"totalPrice\":100.00}")));
+        wm.stubFor(post(urlPathEqualTo("/api/payments"))
+                .willReturn(aResponse()
+                        .withStatus(201)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"id\":1,\"bookingId\":1,\"amount\":100.00," +
+                                  "\"status\":\"PAID\",\"transactionId\":\"TXN-WIREMOCK-002\"}")));
+        // User Service is down — 503
+        wm.stubFor(patch(urlPathMatching("/api/loyalty/user/\\d+/add-points"))
+                .willReturn(aResponse().withStatus(503)));
+
+        ResponseEntity<BookingResponseDTO> response = restTemplate.postForEntity(
+                "/api/bookings/orchestrated?paymentMethod=CREDIT_CARD",
+                buildRequest(),
+                BookingResponseDTO.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        List<Booking> bookings = bookingRepository.findAll();
+        assertThat(bookings).hasSize(1);
+        assertThat(bookings.get(0).getStatus()).isEqualTo(Booking.BookingStatus.CONFIRMED);
+    }
+}

--- a/Payment Service/pom.xml
+++ b/Payment Service/pom.xml
@@ -115,6 +115,20 @@
             <artifactId>spring-rabbit-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-openfeign</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-circuitbreaker-resilience4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8-standalone</artifactId>
+            <version>3.0.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/Payment Service/src/main/java/ba/nwt/paymentservice/PaymentServiceApplication.java
+++ b/Payment Service/src/main/java/ba/nwt/paymentservice/PaymentServiceApplication.java
@@ -2,8 +2,10 @@ package ba.nwt.paymentservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class PaymentServiceApplication {
 
     public static void main(String[] args) {

--- a/Payment Service/src/main/java/ba/nwt/paymentservice/client/UserServiceClient.java
+++ b/Payment Service/src/main/java/ba/nwt/paymentservice/client/UserServiceClient.java
@@ -1,0 +1,27 @@
+package ba.nwt.paymentservice.client;
+
+import ba.nwt.paymentservice.client.dto.UserView;
+import ba.nwt.paymentservice.config.FeignConfig;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+/**
+ * Synchronous Feign client for User Service.
+ * Used in PaymentService#create to validate that the paying user exists
+ * before any payment record is persisted.
+ *
+ * Failure semantics:
+ *   - User not found (404)  → DownstreamBadRequestException → GlobalExceptionHandler → 400
+ *   - User Service down (5xx) → DownstreamUnavailableException → GlobalExceptionHandler → 503
+ */
+@FeignClient(
+        name = "user-service",
+        configuration = FeignConfig.class,
+        fallbackFactory = UserServiceClientFallback.Factory.class
+)
+public interface UserServiceClient {
+
+    @GetMapping("/api/users/{id}")
+    UserView getUser(@PathVariable("id") Long id);
+}

--- a/Payment Service/src/main/java/ba/nwt/paymentservice/client/UserServiceClientFallback.java
+++ b/Payment Service/src/main/java/ba/nwt/paymentservice/client/UserServiceClientFallback.java
@@ -1,0 +1,34 @@
+package ba.nwt.paymentservice.client;
+
+import ba.nwt.paymentservice.client.dto.UserView;
+import ba.nwt.paymentservice.exception.DownstreamUnavailableException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.openfeign.FallbackFactory;
+import org.springframework.stereotype.Component;
+
+public class UserServiceClientFallback implements UserServiceClient {
+
+    private static final Logger log = LoggerFactory.getLogger(UserServiceClientFallback.class);
+    private final Throwable cause;
+
+    public UserServiceClientFallback(Throwable cause) {
+        this.cause = cause;
+    }
+
+    @Override
+    public UserView getUser(Long id) {
+        log.warn("user-service unavailable while validating user {}: {}",
+                id, cause == null ? "n/a" : cause.toString());
+        throw new DownstreamUnavailableException("user-service",
+                "User service is unavailable; cannot validate user " + id, cause);
+    }
+
+    @Component
+    public static class Factory implements FallbackFactory<UserServiceClient> {
+        @Override
+        public UserServiceClient create(Throwable cause) {
+            return new UserServiceClientFallback(cause);
+        }
+    }
+}

--- a/Payment Service/src/main/java/ba/nwt/paymentservice/client/dto/UserView.java
+++ b/Payment Service/src/main/java/ba/nwt/paymentservice/client/dto/UserView.java
@@ -1,0 +1,13 @@
+package ba.nwt.paymentservice.client.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.*;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UserView {
+    private Long id;
+    private String username;
+    private String email;
+    private String role;
+}

--- a/Payment Service/src/main/java/ba/nwt/paymentservice/config/FeignConfig.java
+++ b/Payment Service/src/main/java/ba/nwt/paymentservice/config/FeignConfig.java
@@ -1,0 +1,76 @@
+package ba.nwt.paymentservice.config;
+
+import ba.nwt.paymentservice.exception.DownstreamBadRequestException;
+import ba.nwt.paymentservice.exception.DownstreamUnavailableException;
+import feign.Request;
+import feign.Response;
+import feign.codec.ErrorDecoder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Per-Feign-client config: connect/read timeouts and an ErrorDecoder that maps
+ * downstream HTTP errors into typed exceptions handled by GlobalExceptionHandler.
+ *
+ * NOT @Configuration — applied per @FeignClient via the `configuration` attribute.
+ */
+public class FeignConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(FeignConfig.class);
+
+    @Bean
+    public Request.Options feignRequestOptions() {
+        return new Request.Options(2, TimeUnit.SECONDS, 5, TimeUnit.SECONDS, true);
+    }
+
+    @Bean
+    public ErrorDecoder feignErrorDecoder() {
+        return new TypedErrorDecoder();
+    }
+
+    static class TypedErrorDecoder implements ErrorDecoder {
+        private final ErrorDecoder defaultDecoder = new Default();
+
+        @Override
+        public Exception decode(String methodKey, Response response) {
+            String service = serviceFromMethodKey(methodKey);
+            String body = readBody(response);
+            int status = response.status();
+            log.warn("Feign {} returned {} for {}: {}", service, status, methodKey, body);
+
+            if (status >= 500 || status == 503 || status == 504) {
+                return new DownstreamUnavailableException(service,
+                        service + " returned " + status + ": " + body);
+            }
+            if (status >= 400 && status < 500) {
+                return new DownstreamBadRequestException(service, status,
+                        service + " returned " + status + ": " + body);
+            }
+            return defaultDecoder.decode(methodKey, response);
+        }
+
+        private String serviceFromMethodKey(String methodKey) {
+            if (methodKey == null) return "downstream";
+            int hash = methodKey.indexOf('#');
+            String simple = hash > 0 ? methodKey.substring(0, hash) : methodKey;
+            int dot = simple.lastIndexOf('.');
+            return dot > 0 ? simple.substring(dot + 1) : simple;
+        }
+
+        private String readBody(Response response) {
+            try {
+                if (response.body() == null) return "";
+                byte[] bytes = response.body().asInputStream().readAllBytes();
+                String s = new String(bytes, StandardCharsets.UTF_8);
+                return s.length() > 300 ? s.substring(0, 300) + "..." : s;
+            } catch (IOException e) {
+                return "<unreadable body>";
+            }
+        }
+    }
+}

--- a/Payment Service/src/main/java/ba/nwt/paymentservice/dto/PaymentRequestDTO.java
+++ b/Payment Service/src/main/java/ba/nwt/paymentservice/dto/PaymentRequestDTO.java
@@ -9,6 +9,7 @@ import java.math.BigDecimal;
 @Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
 public class PaymentRequestDTO {
 
+    private Long userId;
     private Long bookingId;
     private Long rentalId;
 

--- a/Payment Service/src/main/java/ba/nwt/paymentservice/exception/DownstreamBadRequestException.java
+++ b/Payment Service/src/main/java/ba/nwt/paymentservice/exception/DownstreamBadRequestException.java
@@ -1,0 +1,15 @@
+package ba.nwt.paymentservice.exception;
+
+public class DownstreamBadRequestException extends RuntimeException {
+    private final String service;
+    private final int status;
+
+    public DownstreamBadRequestException(String service, int status, String message) {
+        super(message);
+        this.service = service;
+        this.status = status;
+    }
+
+    public String getService() { return service; }
+    public int getStatus() { return status; }
+}

--- a/Payment Service/src/main/java/ba/nwt/paymentservice/exception/DownstreamUnavailableException.java
+++ b/Payment Service/src/main/java/ba/nwt/paymentservice/exception/DownstreamUnavailableException.java
@@ -1,0 +1,19 @@
+package ba.nwt.paymentservice.exception;
+
+public class DownstreamUnavailableException extends RuntimeException {
+    private final String service;
+
+    public DownstreamUnavailableException(String service, String message) {
+        super(message);
+        this.service = service;
+    }
+
+    public DownstreamUnavailableException(String service, String message, Throwable cause) {
+        super(message, cause);
+        this.service = service;
+    }
+
+    public String getService() {
+        return service;
+    }
+}

--- a/Payment Service/src/main/java/ba/nwt/paymentservice/exception/GlobalExceptionHandler.java
+++ b/Payment Service/src/main/java/ba/nwt/paymentservice/exception/GlobalExceptionHandler.java
@@ -66,6 +66,32 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
     }
 
+    @ExceptionHandler(ba.nwt.paymentservice.exception.DownstreamUnavailableException.class)
+    public ResponseEntity<ApiError> handleDownstreamUnavailable(
+            ba.nwt.paymentservice.exception.DownstreamUnavailableException ex) {
+        ApiError error = ApiError.builder()
+                .timestamp(LocalDateTime.now())
+                .status(HttpStatus.SERVICE_UNAVAILABLE.value())
+                .error("Service Unavailable")
+                .message(ex.getMessage())
+                .details(List.of("downstream: " + ex.getService()))
+                .build();
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(error);
+    }
+
+    @ExceptionHandler(ba.nwt.paymentservice.exception.DownstreamBadRequestException.class)
+    public ResponseEntity<ApiError> handleDownstreamBadRequest(
+            ba.nwt.paymentservice.exception.DownstreamBadRequestException ex) {
+        ApiError error = ApiError.builder()
+                .timestamp(LocalDateTime.now())
+                .status(HttpStatus.BAD_REQUEST.value())
+                .error("Bad Request")
+                .message(ex.getMessage())
+                .details(List.of("downstream: " + ex.getService(), "downstreamStatus: " + ex.getStatus()))
+                .build();
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiError> handleGeneral(Exception ex) {
         ApiError error = ApiError.builder()

--- a/Payment Service/src/main/java/ba/nwt/paymentservice/service/PaymentService.java
+++ b/Payment Service/src/main/java/ba/nwt/paymentservice/service/PaymentService.java
@@ -1,5 +1,6 @@
 package ba.nwt.paymentservice.service;
 
+import ba.nwt.paymentservice.client.UserServiceClient;
 import ba.nwt.paymentservice.config.JsonPatchUtil;
 import ba.nwt.paymentservice.dto.PaymentRequestDTO;
 import ba.nwt.paymentservice.dto.PaymentResponseDTO;
@@ -33,6 +34,7 @@ public class PaymentService {
     private final NotificationRepository notificationRepository;
     private final ModelMapper modelMapper;
     private final JsonPatchUtil jsonPatchUtil;
+    private final UserServiceClient userServiceClient;
 
     public List<PaymentResponseDTO> getAll() {
         return paymentRepository.findAll().stream()
@@ -76,6 +78,13 @@ public class PaymentService {
 
     @Transactional
     public PaymentResponseDTO create(PaymentRequestDTO dto) {
+        // Synchronous validation: confirm the paying user exists before persisting anything.
+        // User not found (404) → DownstreamBadRequestException → 400
+        // User Service down   → DownstreamUnavailableException → 503
+        if (dto.getUserId() != null) {
+            userServiceClient.getUser(dto.getUserId());
+        }
+
         Payment payment = Payment.builder()
                 .bookingId(dto.getBookingId())
                 .rentalId(dto.getRentalId())

--- a/Payment Service/src/test/java/ba/nwt/paymentservice/integration/PaymentFeignWireMockIT.java
+++ b/Payment Service/src/test/java/ba/nwt/paymentservice/integration/PaymentFeignWireMockIT.java
@@ -1,0 +1,165 @@
+package ba.nwt.paymentservice.integration;
+
+import ba.nwt.paymentservice.dto.PaymentRequestDTO;
+import ba.nwt.paymentservice.dto.PaymentResponseDTO;
+import ba.nwt.paymentservice.model.Payment;
+import ba.nwt.paymentservice.repository.PaymentRepository;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * WireMock integration tests for synchronous Payment → User Service communication.
+ *
+ * Business rule: before persisting a payment, Payment Service synchronously calls
+ * User Service (GET /api/users/{id}) to confirm the paying user exists.
+ *
+ * Test levels covered here:
+ *   - Happy path: user exists → payment created 201
+ *   - User not found (404 from User Service) → payment rejected 400
+ *   - User Service down (503 from User Service) → payment rejected 503
+ *   - No userId provided → validation skipped, payment created normally
+ *
+ * The Feign client (UserServiceClient) is redirected to a local WireMock server via
+ * spring.cloud.openfeign.client.config.user-service.url so no real service is needed.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class PaymentFeignWireMockIT {
+
+    @RegisterExtension
+    static WireMockExtension wm = WireMockExtension.newInstance()
+            .options(wireMockConfig().dynamicPort())
+            .build();
+
+    @DynamicPropertySource
+    static void overrideFeignUrls(DynamicPropertyRegistry registry) {
+        registry.add("spring.cloud.openfeign.client.config.user-service.url",
+                () -> "http://localhost:" + wm.getPort());
+    }
+
+    @MockBean
+    private RabbitTemplate rabbitTemplate;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private PaymentRepository paymentRepository;
+
+    @BeforeEach
+    void cleanUp() {
+        paymentRepository.deleteAll();
+        wm.resetAll();
+    }
+
+    private PaymentRequestDTO buildRequest(Long userId) {
+        return PaymentRequestDTO.builder()
+                .userId(userId)
+                .bookingId(1L)
+                .amount(new BigDecimal("50.00"))
+                .paymentMethod(Payment.PaymentMethod.CREDIT_CARD)
+                .status(Payment.PaymentStatus.PAID)
+                .build();
+    }
+
+    // ── Tests ────────────────────────────────────────────────────────────────
+
+    /**
+     * User Service confirms the user exists (200).
+     * Payment Service creates the payment and returns 201.
+     * Verifies that the GET /api/users/{id} call was actually made via Feign.
+     */
+    @Test
+    void userExists_paymentCreated_returns201() {
+        wm.stubFor(get(urlPathEqualTo("/api/users/1"))
+                .willReturn(okJson(
+                        "{\"id\":1,\"username\":\"john\",\"email\":\"john@example.com\",\"role\":\"USER\"}")));
+
+        ResponseEntity<PaymentResponseDTO> response = restTemplate.postForEntity(
+                "/api/payments", buildRequest(1L), PaymentResponseDTO.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getStatus()).isEqualTo(Payment.PaymentStatus.PAID);
+
+        List<Payment> payments = paymentRepository.findAll();
+        assertThat(payments).hasSize(1);
+
+        // Feign really sent GET /api/users/1 to User Service
+        wm.verify(getRequestedFor(urlPathEqualTo("/api/users/1")));
+    }
+
+    /**
+     * User Service returns 404 — the user does not exist.
+     * TypedErrorDecoder maps 404 → DownstreamBadRequestException.
+     * GlobalExceptionHandler maps it → HTTP 400.
+     * No payment must be persisted.
+     */
+    @Test
+    void userNotFound_returns400_noPaymentPersisted() {
+        wm.stubFor(get(urlPathEqualTo("/api/users/99"))
+                .willReturn(aResponse()
+                        .withStatus(404)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"message\":\"User not found with id: 99\"}")));
+
+        ResponseEntity<String> response = restTemplate.postForEntity(
+                "/api/payments", buildRequest(99L), String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(paymentRepository.findAll()).isEmpty();
+    }
+
+    /**
+     * User Service returns 503 — service is down.
+     * TypedErrorDecoder maps 5xx → DownstreamUnavailableException.
+     * GlobalExceptionHandler maps it → HTTP 503.
+     * No payment must be persisted.
+     */
+    @Test
+    void userServiceDown_returns503_noPaymentPersisted() {
+        wm.stubFor(get(urlPathEqualTo("/api/users/1"))
+                .willReturn(aResponse().withStatus(503)));
+
+        ResponseEntity<String> response = restTemplate.postForEntity(
+                "/api/payments", buildRequest(1L), String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        assertThat(paymentRepository.findAll()).isEmpty();
+    }
+
+    /**
+     * No userId in the request — validation is skipped entirely.
+     * Payment is created normally without any call to User Service.
+     */
+    @Test
+    void noUserId_validationSkipped_paymentCreated_returns201() {
+        ResponseEntity<PaymentResponseDTO> response = restTemplate.postForEntity(
+                "/api/payments", buildRequest(null), PaymentResponseDTO.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(paymentRepository.findAll()).hasSize(1);
+
+        // No call to User Service was made
+        wm.verify(0, getRequestedFor(urlPathMatching("/api/users/.*")));
+    }
+}

--- a/Payment Service/src/test/resources/application-test.properties
+++ b/Payment Service/src/test/resources/application-test.properties
@@ -15,6 +15,9 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
 
 spring.main.allow-bean-definition-overriding=true
 
+# ── Feign ──
+spring.cloud.openfeign.circuitbreaker.enabled=false
+
 # ── Disable external services ──
 eureka.client.enabled=false
 eureka.client.register-with-eureka=false

--- a/SINHRONA_KOMUNIKACIJA.md
+++ b/SINHRONA_KOMUNIKACIJA.md
@@ -1,0 +1,264 @@
+# Sinhrona komunikacija između mikroservisa — SportsCenterSystem
+
+## 1. Šta je Feign Client?
+
+**OpenFeign** je deklarativni HTTP klijent za Spring Cloud. Umjesto da ručno kreiramo
+`RestTemplate` pozive, definišemo **Java interfejs** s anotacijama, a Spring Cloud OpenFeign
+automatski generiše implementaciju koja pravi prave HTTP zahtjeve.
+
+```java
+// Ovo je sve što pišemo — Feign generiše HTTP klijenta
+@FeignClient(name = "user-service", configuration = FeignConfig.class, ...)
+public interface UserServiceClient {
+    @GetMapping("/api/users/{id}")
+    UserView getUser(@PathVariable("id") Long id);
+}
+
+// Koristimo ga kao običan Spring bean
+UserView user = userServiceClient.getUser(1L);
+// Feign šalje: GET http://user-service/api/users/1
+```
+
+Ime servisa (`"user-service"`) ne resolviše se u hardkodiranu adresu — Spring Cloud Load
+Balancer pita **Eureka** registar za stvarnu IP adresu i port trenutno dostupne instance.
+
+---
+
+## 2. Gdje je implementirana sinhrona komunikacija i zašto baš tu?
+
+### Payment Service → User Service
+
+**Implementirana u:** `Payment Service`  
+**Poziva:** `User Service`  
+**Razlog:** Prije nego Payment Service persistuje novi zapis o plaćanju, mora sinhrono
+potvrditi da korisnik koji plaća **postoji** u sistemu.
+
+Ovo je klasičan primjer **validacije podataka kao međukoraka**:
+- Bez ovog poziva, Payment Service bi kreirao plaćanje za nepostojećeg korisnika
+- Rezultat validacije (user postoji / ne postoji) blokira dalje izvršavanje — zato je sinhrona
+- Nema smisla asinhrono — ako korisnik ne postoji, odmah vraćamo grešku, ne čekamo
+
+**Zašto Payment Service poziva User Service, a ne obrnuto?**  
+Payment Service je taj koji prima zahtjev za kreiranje plaćanja i koji treba podatak.
+User Service je samo provajder podataka o korisnicima — ne zna ništa o plaćanjima.
+
+---
+
+## 3. Kako funkcioniše — korak po korak
+
+**Endpoint:** `POST /api/payments`  
+**Fajl:** `Payment Service/src/main/java/ba/nwt/paymentservice/service/PaymentService.java`
+
+```
+Klijent šalje: POST /api/payments  { userId: 1, bookingId: 5, amount: 100.00, paymentMethod: CREDIT_CARD }
+                    │
+                    ▼
+            PaymentService.create(dto)
+                    │
+                    ├── dto.getUserId() != null?
+                    │       │
+                    │       ▼
+                    │   userServiceClient.getUser(1L)
+                    │       │
+                    │       ▼  (Feign šalje HTTP)
+                    │   GET http://user-service/api/users/1
+                    │       │
+                    │   ┌───┴────────────────────────────┐
+                    │   │ 200 OK → UserView              │  → nastavi
+                    │   │ 404 Not Found                  │  → DownstreamBadRequestException → 400
+                    │   │ 503 Service Unavailable        │  → DownstreamUnavailableException → 503
+                    │   └────────────────────────────────┘
+                    │
+                    ▼  (samo ako je user validiran)
+            paymentRepository.save(payment)
+                    │
+                    ▼
+            201 Created + PaymentResponseDTO
+```
+
+---
+
+## 4. Ključni fajlovi implementacije
+
+| Fajl | Uloga |
+|---|---|
+| `Payment Service/.../client/UserServiceClient.java` | Feign interfejs — deklarativni HTTP klijent |
+| `Payment Service/.../client/UserServiceClientFallback.java` | Fallback factory — šta se desi kad User Service ne odgovori |
+| `Payment Service/.../client/dto/UserView.java` | DTO za odgovor User Servicea |
+| `Payment Service/.../config/FeignConfig.java` | Timeout (2s connect, 5s read) + TypedErrorDecoder |
+| `Payment Service/.../service/PaymentService.java` | Poziva `userServiceClient.getUser()` u `create()` |
+| `Payment Service/.../exception/DownstreamUnavailableException.java` | Za 5xx greške od User Service |
+| `Payment Service/.../exception/DownstreamBadRequestException.java` | Za 4xx greške od User Service (uključuje 404) |
+| `Payment Service/.../exception/GlobalExceptionHandler.java` | Mapira iznimke u HTTP status kodove |
+
+### UserServiceClient (Feign interfejs)
+
+```java
+@FeignClient(
+    name = "user-service",          // Eureka ime servisa — bez hardkodirane adrese
+    configuration = FeignConfig.class,
+    fallbackFactory = UserServiceClientFallback.Factory.class
+)
+public interface UserServiceClient {
+    @GetMapping("/api/users/{id}")
+    UserView getUser(@PathVariable("id") Long id);
+}
+```
+
+### FeignConfig — timeout i error decoder
+
+```java
+// Timeout: 2s spajanje, 5s čitanje — brz fail, ne blokira threadove
+@Bean
+public Request.Options feignRequestOptions() {
+    return new Request.Options(2, TimeUnit.SECONDS, 5, TimeUnit.SECONDS, true);
+}
+
+// TypedErrorDecoder: HTTP status → Java iznimka
+// 5xx → DownstreamUnavailableException
+// 4xx → DownstreamBadRequestException
+```
+
+### Eureka — bez hardkodiranih adresa
+
+```properties
+# config-repo/application.properties
+eureka.client.service-url.defaultZone=http://localhost:8761/eureka/
+```
+Feign koristi `name = "user-service"` — Eureka registar vraća stvarnu adresu. Nema IP-a u kodu.
+
+---
+
+## 5. Postojeća sinhrona komunikacija — Booking Service orkestracija
+
+Pored Payment → User, Booking Service već koristi sinhronu komunikaciju sa tri servisa
+kroz endpoint `POST /api/bookings/orchestrated`.
+
+**Fajlovi:**
+- `Booking Service/.../client/ResourceServiceClient.java`
+- `Booking Service/.../client/PaymentServiceClient.java`
+- `Booking Service/.../client/UserServiceClient.java`
+- `Booking Service/.../service/BookingService.java` → metoda `createOrchestrated()`
+
+**Tok:**
+```
+POST /api/bookings/orchestrated
+        │
+        ├── GET /api/facilities/{id}              → Resource Service  (validacija objekta)
+        ├── GET /api/pricing-rules/calculate      → Resource Service  (autoritativna cijena)
+        ├── [DB: INSERT booking PENDING]
+        ├── POST /api/payments  { userId, bookingId, amount }  → Payment Service
+        │       └── Payment Service interno: GET /api/users/{userId} → User Service  ← nova sinhrona
+        ├── [DB: UPDATE booking CONFIRMED]
+        └── PATCH /api/loyalty/user/{id}/add-points → User Service (best-effort)
+```
+
+Sada kad Payment Service prima zahtjev od Booking Servicea, on **sam sinhrono validira korisnika**
+prema User Serviceu — Booking Service ne mora to raditi posebno jer `userId` proslijeđuje u
+payment requestu.
+
+**Failure semantics (Booking orkestracija):**
+
+| Korak | Servis nedostupan | Rezultat |
+|---|---|---|
+| Validacija objekta | Resource Service → 503 | 503, ništa nije sačuvano u DB |
+| Izračun cijene | Resource Service → 503 | 503, ništa nije sačuvano u DB |
+| Plaćanje | Payment Service → 503 | 503, booking ostaje CANCELLED u DB |
+| Validacija usera u plaćanju | User Service → 503 | 503, booking ostaje CANCELLED u DB |
+| Loyalty poeni | User Service → 503 | 201, booking je CONFIRMED (best-effort) |
+
+**Testovi za Booking orkestraciju:**
+- `Booking Service/.../service/BookingServiceZ5OrchestrationTest.java` — unit testovi (7 scenarija)
+- `Booking Service/.../controller/BookingControllerZ5Test.java` — HTTP status kod mapiranje
+- `Booking Service/.../client/FeignFallbacksTest.java` — fallback ponašanje po klijentu
+- `Booking Service/.../integration/BookingFeignWireMockIT.java` — WireMock HTTP nivo (5 scenarija)
+
+---
+
+## 6. Kako je komunikacija testirana?
+
+### Nivo 1 — Unit testovi (mock na Java nivou)
+
+Postojeći testovi za Payment Service (`PaymentServiceTest`, `PaymentControllerTest`) mockuju
+`UserServiceClient` kao `@MockBean` i testiraju poslovnu logiku.
+
+### Nivo 2 — WireMock integracijski testovi (HTTP nivo)
+
+**Fajl:** `Payment Service/src/test/java/ba/nwt/paymentservice/integration/PaymentFeignWireMockIT.java`
+
+Pokreće pravi WireMock HTTP server. Feign klijent se usmjerava na WireMock putem
+`spring.cloud.openfeign.client.config.user-service.url` (`@DynamicPropertySource`).
+
+Ovo testira da Feign ispravno:
+- konstruiše URL (`/api/users/{id}`)
+- deserijalizira response u `UserView`
+- `TypedErrorDecoder` mapira 404 → `DownstreamBadRequestException`
+- `TypedErrorDecoder` mapira 503 → `DownstreamUnavailableException`
+
+| Test | Scenario | Očekivani rezultat |
+|---|---|---|
+| `userExists_paymentCreated_returns201` | User Service → 200 | 201, payment u DB, WireMock verifikuje HTTP poziv |
+| `userNotFound_returns400_noPaymentPersisted` | User Service → 404 | 400, nema zapisa u DB |
+| `userServiceDown_returns503_noPaymentPersisted` | User Service → 503 | 503, nema zapisa u DB |
+| `noUserId_validationSkipped_paymentCreated_returns201` | userId = null | 201, nema HTTP poziva ka User Service |
+
+---
+
+## 6. Šta kada mikroservisi nisu dostupni?
+
+### Problem
+
+Sinhrona komunikacija znači da pozivajući servis **čeka** odgovor. Ako pozvani servis ne odgovori,
+pozivajući servis čeka dok ne istekne timeout — i korisnik čeka s njim. Uz to, kaskadni padovi
+(*cascade failure*) mogu srušiti čitav sistem ako mnogo servisa poziva isti nedostupni servis.
+
+### Kako je ovo riješeno u projektu?
+
+#### Kratki timeoutovi (`FeignConfig.java`)
+```java
+new Request.Options(2, TimeUnit.SECONDS, 5, TimeUnit.SECONDS, true)
+```
+Feign neće čekati duže od 5 sekundi. Brz fail oslobađa threadove.
+
+#### Circuit Breaker — Resilience4j
+```properties
+# config-repo/booking-service-dev.properties (isti pattern primjenjiv za payment-service)
+resilience4j.circuitbreaker.configs.default.failureRateThreshold=50
+resilience4j.circuitbreaker.configs.default.waitDurationInOpenState=10s
+```
+Ako > 50% poziva ne uspije, circuit breaker se **otvori** — sljedeći pozivi odmah padaju bez
+čekanja. Nakon 10s prelazi u polu-otvoreno stanje i testira oporavak.
+
+#### Fallback Factory (`UserServiceClientFallback.java`)
+```java
+@Override
+public UserView getUser(Long id) {
+    throw new DownstreamUnavailableException("user-service",
+            "User service is unavailable; cannot validate user " + id, cause);
+}
+```
+Kada circuit breaker aktivira fallback, Payment Service odmah vraća 503 — bez čekanja na timeout.
+
+#### TypedErrorDecoder — HTTP greške → tipske iznimke
+```
+HTTP 404 → DownstreamBadRequestException → GlobalExceptionHandler → 400 Bad Request
+HTTP 503 → DownstreamUnavailableException → GlobalExceptionHandler → 503 Service Unavailable
+```
+
+### Kako smanjiti međuzavisnost uz sinhronu komunikaciju?
+
+Sinhrona komunikacija inherentno stvara neku međuzavisnost, ali ona se minimizira:
+
+1. **Circuit Breaker** — pozivajući servis ne čeka do timeauta; otvoreni circuit odmah vraća grešku.
+
+2. **Kratki timeoutovi** — maksimalno 5 sekundi čekanja, ne blokira threadove servera.
+
+3. **Sinhrono samo tamo gdje je nužno** — Payment → User Service je sinhrono jer validacija
+   mora biti završena prije naplate. Za sve ostalo (obavijesti, loyalty, saga kompenzacije)
+   koristi se **asinhorna komunikacija** (RabbitMQ — implementirano u Z7).
+
+4. **Graceful degradation** — razlikovati kritične od nekritičnih poziva. Npr. validacija
+   korisnika je kritična (bez nje nema plaćanja), loyalty krediti nisu (failure se gutira).
+
+**Zaključak:** koristiti sinhronu komunikaciju samo tamo gdje rezultat ODMAH blokira nastavak
+toka. Sve ostalo — asinhrono.


### PR DESCRIPTION
PR: Synchronous inter-service communication

  Summary

  - Implement synchronous Feign-based communication between Payment Service → User Service: validate that the paying user exists before any payment record is persisted
  - Add WireMock HTTP-level integration tests for both the new Payment→User communication and the existing Booking orchestration flow
  - Document all synchronous communication patterns, Feign client architecture, failure handling, and the unavailability question in SINHRONA_KOMUNIKACIJA.md

  Changes

  Payment Service — new synchronous communication
  - Added spring-cloud-starter-openfeign, spring-cloud-starter-circuitbreaker-resilience4j, and wiremock-jre8-standalone dependencies
  - @EnableFeignClients on PaymentServiceApplication
  - UserServiceClient — Feign interface calling GET /api/users/{id} on User Service
  - UserServiceClientFallback — fallback factory; throws DownstreamUnavailableException when User Service is down
  - FeignConfig — 2s connect / 5s read timeout + TypedErrorDecoder mapping HTTP status codes to typed exceptions (5xx → DownstreamUnavailableException, 4xx → DownstreamBadRequestException)
  - DownstreamUnavailableException + DownstreamBadRequestException
  - GlobalExceptionHandler updated: DownstreamUnavailableException → 503, DownstreamBadRequestException → 400
  - PaymentRequestDTO — added userId field
  - PaymentService.create() — calls userServiceClient.getUser(userId) before persisting; if user is not found (404) the payment is rejected (400); if User Service is down (5xx) the payment is rejected (503); if userId is null the check is
  skipped

  Booking Service — minor update
  - PaymentCreateView — added userId field
  - BookingService.createOrchestrated() — passes userId to the payment request so Payment Service can validate the user internally

  Tests
  - PaymentFeignWireMockIT — 4 WireMock integration tests at the HTTP level: user exists → 201, user not found → 400, User Service down → 503, no userId → validation skipped
  - BookingFeignWireMockIT — 5 WireMock integration tests for the existing Booking orchestration flow: happy path (verifies all HTTP calls were made), resource down, facility inactive, payment down, User Service down (best-effort)
