### PR TITLE
feat: Extend RabbitMQ Saga Choreography to all cross-service operations

### DIFF
--- a/Booking Service/src/main/java/ba/nwt/bookingservice/config/RabbitMQConfig.java
+++ b/Booking Service/src/main/java/ba/nwt/bookingservice/config/RabbitMQConfig.java
@@ -11,70 +11,77 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class RabbitMQConfig {
 
-    // ── Exchange ──────────────────────────────────────────────────────────────
     public static final String SAGA_EXCHANGE = "sportcenter.saga.exchange";
 
-    // ── Queue names ───────────────────────────────────────────────────────────
-    /** Payment Service consumes this queue */
+    // ── Saga 1: Booking Creation (existing) ───────────────────────────────────
     public static final String BOOKING_CREATED_QUEUE   = "sportcenter.booking.created.queue";
-    /** Booking Service consumes this queue */
     public static final String PAYMENT_COMPLETED_QUEUE = "sportcenter.payment.completed.queue";
-    /** Booking Service consumes this queue */
     public static final String PAYMENT_FAILED_QUEUE    = "sportcenter.payment.failed.queue";
 
-    // ── Routing keys ──────────────────────────────────────────────────────────
     public static final String BOOKING_CREATED_KEY   = "booking.saga.created";
     public static final String PAYMENT_COMPLETED_KEY = "payment.saga.completed";
     public static final String PAYMENT_FAILED_KEY    = "payment.saga.failed";
 
-    // ── Exchange bean ─────────────────────────────────────────────────────────
+    // ── Saga 2: Booking Cancellation + Refund ─────────────────────────────────
+    public static final String BOOKING_CANCELLATION_QUEUE = "sportcenter.booking.cancellation.queue";
+    public static final String REFUND_COMPLETED_QUEUE     = "sportcenter.refund.completed.queue";
+    public static final String REFUND_FAILED_QUEUE        = "sportcenter.refund.failed.queue";
+
+    public static final String BOOKING_CANCELLATION_KEY = "booking.saga.cancellation";
+    public static final String REFUND_COMPLETED_KEY     = "refund.saga.completed";
+    public static final String REFUND_FAILED_KEY        = "refund.saga.failed";
+
+    // ── Saga 3: Rental + Payment ──────────────────────────────────────────────
+    public static final String RENTAL_CREATED_QUEUE           = "sportcenter.rental.created.queue";
+    public static final String RENTAL_PAYMENT_COMPLETED_QUEUE = "sportcenter.rental.payment.completed.queue";
+    public static final String RENTAL_PAYMENT_FAILED_QUEUE    = "sportcenter.rental.payment.failed.queue";
+
+    public static final String RENTAL_CREATED_KEY           = "rental.saga.created";
+    public static final String RENTAL_PAYMENT_COMPLETED_KEY = "rental.payment.saga.completed";
+    public static final String RENTAL_PAYMENT_FAILED_KEY    = "rental.payment.saga.failed";
+
+    // ── Saga 4: User Deletion ─────────────────────────────────────────────────
+    public static final String USER_DELETION_QUEUE           = "sportcenter.user.deletion.queue";
+    public static final String USER_BOOKINGS_CANCELLED_QUEUE = "sportcenter.user.bookings.cancelled.queue";
+    public static final String USER_BOOKINGS_FAILED_QUEUE    = "sportcenter.user.bookings.failed.queue";
+
+    public static final String USER_DELETION_KEY           = "user.saga.deletion";
+    public static final String USER_BOOKINGS_CANCELLED_KEY = "user.saga.bookings.cancelled";
+    public static final String USER_BOOKINGS_FAILED_KEY    = "user.saga.bookings.failed";
+
     @Bean
     public TopicExchange sagaExchange() {
         return ExchangeBuilder.topicExchange(SAGA_EXCHANGE).durable(true).build();
     }
 
-    // ── Queues declared by Booking Service (the ones it consumes) ─────────────
-    @Bean
-    public Queue paymentCompletedQueue() {
-        return QueueBuilder.durable(PAYMENT_COMPLETED_QUEUE).build();
-    }
-
-    @Bean
-    public Queue paymentFailedQueue() {
-        return QueueBuilder.durable(PAYMENT_FAILED_QUEUE).build();
-    }
-
-    // Also declare the queue that Payment Service will consume so RabbitMQ
-    // creates it before the Payment Service starts (avoids AMQP 404 errors).
-    @Bean
-    public Queue bookingCreatedQueue() {
-        return QueueBuilder.durable(BOOKING_CREATED_QUEUE).build();
-    }
+    // ── Queues ────────────────────────────────────────────────────────────────
+    @Bean public Queue bookingCreatedQueue()           { return QueueBuilder.durable(BOOKING_CREATED_QUEUE).build(); }
+    @Bean public Queue paymentCompletedQueue()         { return QueueBuilder.durable(PAYMENT_COMPLETED_QUEUE).build(); }
+    @Bean public Queue paymentFailedQueue()            { return QueueBuilder.durable(PAYMENT_FAILED_QUEUE).build(); }
+    @Bean public Queue bookingCancellationQueue()      { return QueueBuilder.durable(BOOKING_CANCELLATION_QUEUE).build(); }
+    @Bean public Queue refundCompletedQueue()          { return QueueBuilder.durable(REFUND_COMPLETED_QUEUE).build(); }
+    @Bean public Queue refundFailedQueue()             { return QueueBuilder.durable(REFUND_FAILED_QUEUE).build(); }
+    @Bean public Queue rentalCreatedQueue()            { return QueueBuilder.durable(RENTAL_CREATED_QUEUE).build(); }
+    @Bean public Queue rentalPaymentCompletedQueue()   { return QueueBuilder.durable(RENTAL_PAYMENT_COMPLETED_QUEUE).build(); }
+    @Bean public Queue rentalPaymentFailedQueue()      { return QueueBuilder.durable(RENTAL_PAYMENT_FAILED_QUEUE).build(); }
+    @Bean public Queue userDeletionQueue()             { return QueueBuilder.durable(USER_DELETION_QUEUE).build(); }
+    @Bean public Queue userBookingsCancelledQueue()    { return QueueBuilder.durable(USER_BOOKINGS_CANCELLED_QUEUE).build(); }
+    @Bean public Queue userBookingsFailedQueue()       { return QueueBuilder.durable(USER_BOOKINGS_FAILED_QUEUE).build(); }
 
     // ── Bindings ──────────────────────────────────────────────────────────────
-    @Bean
-    public Binding bookingCreatedBinding() {
-        return BindingBuilder.bind(bookingCreatedQueue())
-                .to(sagaExchange()).with(BOOKING_CREATED_KEY);
-    }
+    @Bean public Binding bookingCreatedBinding()         { return BindingBuilder.bind(bookingCreatedQueue()).to(sagaExchange()).with(BOOKING_CREATED_KEY); }
+    @Bean public Binding paymentCompletedBinding()       { return BindingBuilder.bind(paymentCompletedQueue()).to(sagaExchange()).with(PAYMENT_COMPLETED_KEY); }
+    @Bean public Binding paymentFailedBinding()          { return BindingBuilder.bind(paymentFailedQueue()).to(sagaExchange()).with(PAYMENT_FAILED_KEY); }
+    @Bean public Binding bookingCancellationBinding()    { return BindingBuilder.bind(bookingCancellationQueue()).to(sagaExchange()).with(BOOKING_CANCELLATION_KEY); }
+    @Bean public Binding refundCompletedBinding()        { return BindingBuilder.bind(refundCompletedQueue()).to(sagaExchange()).with(REFUND_COMPLETED_KEY); }
+    @Bean public Binding refundFailedBinding()           { return BindingBuilder.bind(refundFailedQueue()).to(sagaExchange()).with(REFUND_FAILED_KEY); }
+    @Bean public Binding rentalCreatedBinding()          { return BindingBuilder.bind(rentalCreatedQueue()).to(sagaExchange()).with(RENTAL_CREATED_KEY); }
+    @Bean public Binding rentalPaymentCompletedBinding() { return BindingBuilder.bind(rentalPaymentCompletedQueue()).to(sagaExchange()).with(RENTAL_PAYMENT_COMPLETED_KEY); }
+    @Bean public Binding rentalPaymentFailedBinding()    { return BindingBuilder.bind(rentalPaymentFailedQueue()).to(sagaExchange()).with(RENTAL_PAYMENT_FAILED_KEY); }
+    @Bean public Binding userDeletionBinding()           { return BindingBuilder.bind(userDeletionQueue()).to(sagaExchange()).with(USER_DELETION_KEY); }
+    @Bean public Binding userBookingsCancelledBinding()  { return BindingBuilder.bind(userBookingsCancelledQueue()).to(sagaExchange()).with(USER_BOOKINGS_CANCELLED_KEY); }
+    @Bean public Binding userBookingsFailedBinding()     { return BindingBuilder.bind(userBookingsFailedQueue()).to(sagaExchange()).with(USER_BOOKINGS_FAILED_KEY); }
 
-    @Bean
-    public Binding paymentCompletedBinding() {
-        return BindingBuilder.bind(paymentCompletedQueue())
-                .to(sagaExchange()).with(PAYMENT_COMPLETED_KEY);
-    }
-
-    @Bean
-    public Binding paymentFailedBinding() {
-        return BindingBuilder.bind(paymentFailedQueue())
-                .to(sagaExchange()).with(PAYMENT_FAILED_KEY);
-    }
-
-    // ── JSON message converter ─────────────────────────────────────────────────
-    // Inject Spring Boot's ObjectMapper (has JavaTimeModule → LocalDateTime works).
-    // INFERRED type precedence: use @RabbitListener method's parameter type for
-    // deserialization instead of the __TypeId__ header, which would contain the
-    // sender's package name (not present in this service's classpath).
     @Bean
     public MessageConverter jsonMessageConverter(ObjectMapper objectMapper) {
         Jackson2JsonMessageConverter converter = new Jackson2JsonMessageConverter(objectMapper);

--- a/Booking Service/src/main/java/ba/nwt/bookingservice/controller/BookingCancellationSagaController.java
+++ b/Booking Service/src/main/java/ba/nwt/bookingservice/controller/BookingCancellationSagaController.java
@@ -1,0 +1,36 @@
+package ba.nwt.bookingservice.controller;
+
+import ba.nwt.bookingservice.dto.BookingResponseDTO;
+import ba.nwt.bookingservice.service.BookingCancellationSagaService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * POST /api/bookings/{id}/cancel
+ *
+ * Initiates the Booking Cancellation Saga:
+ * 1. Booking CONFIRMED → CANCELLATION_PENDING (local TX 1)
+ * 2. Payment Service processes refund (local TX 2)
+ *    → Refund OK  → Booking CANCELLED           (final state)
+ *    → Refund KO  → Booking restored CONFIRMED  (compensating action)
+ */
+@RestController
+@RequestMapping("/api/bookings")
+@RequiredArgsConstructor
+@Tag(name = "Booking Cancellation Saga", description = "Async cancellation with refund via RabbitMQ")
+public class BookingCancellationSagaController {
+
+    private final BookingCancellationSagaService service;
+
+    @PostMapping("/{id}/cancel")
+    @Operation(summary = "Cancel a confirmed booking with async refund (Saga Choreography)")
+    public ResponseEntity<BookingResponseDTO> cancel(
+            @PathVariable Long id,
+            @RequestParam(defaultValue = "false") boolean simulateFailure) {
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(service.initiate(id, simulateFailure));
+    }
+}

--- a/Booking Service/src/main/java/ba/nwt/bookingservice/controller/RentalSagaController.java
+++ b/Booking Service/src/main/java/ba/nwt/bookingservice/controller/RentalSagaController.java
@@ -1,0 +1,39 @@
+package ba.nwt.bookingservice.controller;
+
+import ba.nwt.bookingservice.dto.EquipmentRentalRequestDTO;
+import ba.nwt.bookingservice.dto.EquipmentRentalResponseDTO;
+import ba.nwt.bookingservice.service.RentalSagaService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * POST /api/rentals/saga
+ *
+ * Initiates the Equipment Rental + Payment Saga:
+ * 1. Rental saved as RESERVED (local TX 1)
+ * 2. Payment Service creates payment (local TX 2)
+ *    → Payment OK  → Rental stays RESERVED (confirmed, final state)
+ *    → Payment KO  → Rental CANCELLED (compensating action)
+ */
+@RestController
+@RequestMapping("/api/rentals")
+@RequiredArgsConstructor
+@Tag(name = "Rental Saga", description = "Async equipment rental with payment via RabbitMQ")
+public class RentalSagaController {
+
+    private final RentalSagaService rentalSagaService;
+
+    @PostMapping("/saga")
+    @Operation(summary = "Create equipment rental with async payment (Saga Choreography)")
+    public ResponseEntity<EquipmentRentalResponseDTO> createViaSaga(
+            @Valid @RequestBody EquipmentRentalRequestDTO dto,
+            @RequestParam(defaultValue = "CREDIT_CARD") String paymentMethod,
+            @RequestParam(defaultValue = "false") boolean simulateFailure) {
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(rentalSagaService.initiate(dto, paymentMethod, simulateFailure));
+    }
+}

--- a/Booking Service/src/main/java/ba/nwt/bookingservice/model/Booking.java
+++ b/Booking Service/src/main/java/ba/nwt/bookingservice/model/Booking.java
@@ -47,7 +47,7 @@ public class Booking {
 
     // ── Enum ──
     public enum BookingStatus {
-        PENDING, CONFIRMED, COMPLETED, CANCELLED, TEMPORARY_HOLD
+        PENDING, CONFIRMED, COMPLETED, CANCELLED, TEMPORARY_HOLD, CANCELLATION_PENDING
     }
 }
 

--- a/Booking Service/src/main/java/ba/nwt/bookingservice/repository/BookingRepository.java
+++ b/Booking Service/src/main/java/ba/nwt/bookingservice/repository/BookingRepository.java
@@ -52,6 +52,8 @@ public interface BookingRepository extends JpaRepository<Booking, Long> {
         return findConflictingByStatuses(facilityId, start, end,
                 List.of(Booking.BookingStatus.PENDING, Booking.BookingStatus.CONFIRMED));
     }
+
+    List<Booking> findByUserIdAndStatusIn(Long userId, List<Booking.BookingStatus> statuses);
 }
 
 

--- a/Booking Service/src/main/java/ba/nwt/bookingservice/saga/BookingCancellationSagaConsumer.java
+++ b/Booking Service/src/main/java/ba/nwt/bookingservice/saga/BookingCancellationSagaConsumer.java
@@ -1,0 +1,33 @@
+package ba.nwt.bookingservice.saga;
+
+import ba.nwt.bookingservice.config.RabbitMQConfig;
+import ba.nwt.bookingservice.saga.event.RefundCompletedEvent;
+import ba.nwt.bookingservice.saga.event.RefundFailedEvent;
+import ba.nwt.bookingservice.service.BookingCancellationSagaService;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BookingCancellationSagaConsumer {
+
+    private static final Logger log = LoggerFactory.getLogger(BookingCancellationSagaConsumer.class);
+    private final BookingCancellationSagaService service;
+
+    /** Refund succeeded → finalize booking as CANCELLED (final state). */
+    @RabbitListener(queues = RabbitMQConfig.REFUND_COMPLETED_QUEUE)
+    public void onRefundCompleted(RefundCompletedEvent event) {
+        log.info("[SAGA-CANCEL][{}] Received RefundCompletedEvent for bookingId={}", event.getSagaId(), event.getBookingId());
+        service.finalizeCancel(event);
+    }
+
+    /** Refund failed → compensating action: restore booking to CONFIRMED. */
+    @RabbitListener(queues = RabbitMQConfig.REFUND_FAILED_QUEUE)
+    public void onRefundFailed(RefundFailedEvent event) {
+        log.warn("[SAGA-CANCEL][{}] Received RefundFailedEvent for bookingId={} reason={}", event.getSagaId(), event.getBookingId(), event.getReason());
+        service.restoreBooking(event);
+    }
+}

--- a/Booking Service/src/main/java/ba/nwt/bookingservice/saga/BookingCancellationSagaPublisher.java
+++ b/Booking Service/src/main/java/ba/nwt/bookingservice/saga/BookingCancellationSagaPublisher.java
@@ -1,0 +1,23 @@
+package ba.nwt.bookingservice.saga;
+
+import ba.nwt.bookingservice.config.RabbitMQConfig;
+import ba.nwt.bookingservice.saga.event.BookingCancellationRequestedEvent;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BookingCancellationSagaPublisher {
+
+    private static final Logger log = LoggerFactory.getLogger(BookingCancellationSagaPublisher.class);
+    private final RabbitTemplate rabbitTemplate;
+
+    public void publishCancellationRequested(BookingCancellationRequestedEvent event) {
+        log.info("[SAGA-CANCEL][{}] Publishing BookingCancellationRequestedEvent for bookingId={}",
+                event.getSagaId(), event.getBookingId());
+        rabbitTemplate.convertAndSend(RabbitMQConfig.SAGA_EXCHANGE, RabbitMQConfig.BOOKING_CANCELLATION_KEY, event);
+    }
+}

--- a/Booking Service/src/main/java/ba/nwt/bookingservice/saga/RentalSagaConsumer.java
+++ b/Booking Service/src/main/java/ba/nwt/bookingservice/saga/RentalSagaConsumer.java
@@ -1,0 +1,31 @@
+package ba.nwt.bookingservice.saga;
+
+import ba.nwt.bookingservice.config.RabbitMQConfig;
+import ba.nwt.bookingservice.saga.event.RentalPaymentCompletedEvent;
+import ba.nwt.bookingservice.saga.event.RentalPaymentFailedEvent;
+import ba.nwt.bookingservice.service.RentalSagaService;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RentalSagaConsumer {
+
+    private static final Logger log = LoggerFactory.getLogger(RentalSagaConsumer.class);
+    private final RentalSagaService rentalSagaService;
+
+    @RabbitListener(queues = RabbitMQConfig.RENTAL_PAYMENT_COMPLETED_QUEUE)
+    public void onRentalPaymentCompleted(RentalPaymentCompletedEvent event) {
+        log.info("[SAGA-RENTAL][{}] Received RentalPaymentCompletedEvent for rentalId={}", event.getSagaId(), event.getRentalId());
+        rentalSagaService.confirmRental(event);
+    }
+
+    @RabbitListener(queues = RabbitMQConfig.RENTAL_PAYMENT_FAILED_QUEUE)
+    public void onRentalPaymentFailed(RentalPaymentFailedEvent event) {
+        log.warn("[SAGA-RENTAL][{}] Received RentalPaymentFailedEvent for rentalId={}", event.getSagaId(), event.getRentalId());
+        rentalSagaService.cancelRental(event);
+    }
+}

--- a/Booking Service/src/main/java/ba/nwt/bookingservice/saga/RentalSagaPublisher.java
+++ b/Booking Service/src/main/java/ba/nwt/bookingservice/saga/RentalSagaPublisher.java
@@ -1,0 +1,22 @@
+package ba.nwt.bookingservice.saga;
+
+import ba.nwt.bookingservice.config.RabbitMQConfig;
+import ba.nwt.bookingservice.saga.event.RentalCreatedEvent;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RentalSagaPublisher {
+
+    private static final Logger log = LoggerFactory.getLogger(RentalSagaPublisher.class);
+    private final RabbitTemplate rabbitTemplate;
+
+    public void publishRentalCreated(RentalCreatedEvent event) {
+        log.info("[SAGA-RENTAL][{}] Publishing RentalCreatedEvent for rentalId={}", event.getSagaId(), event.getRentalId());
+        rabbitTemplate.convertAndSend(RabbitMQConfig.SAGA_EXCHANGE, RabbitMQConfig.RENTAL_CREATED_KEY, event);
+    }
+}

--- a/Booking Service/src/main/java/ba/nwt/bookingservice/saga/UserDeletionBookingSagaConsumer.java
+++ b/Booking Service/src/main/java/ba/nwt/bookingservice/saga/UserDeletionBookingSagaConsumer.java
@@ -1,0 +1,24 @@
+package ba.nwt.bookingservice.saga;
+
+import ba.nwt.bookingservice.config.RabbitMQConfig;
+import ba.nwt.bookingservice.saga.event.UserDeletionRequestedEvent;
+import ba.nwt.bookingservice.service.UserDeletionBookingSagaService;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserDeletionBookingSagaConsumer {
+
+    private static final Logger log = LoggerFactory.getLogger(UserDeletionBookingSagaConsumer.class);
+    private final UserDeletionBookingSagaService service;
+
+    @RabbitListener(queues = RabbitMQConfig.USER_DELETION_QUEUE)
+    public void onUserDeletionRequested(UserDeletionRequestedEvent event) {
+        log.info("[SAGA-USER][{}] Received UserDeletionRequestedEvent for userId={}", event.getSagaId(), event.getUserId());
+        service.cancelUserBookings(event);
+    }
+}

--- a/Booking Service/src/main/java/ba/nwt/bookingservice/saga/UserDeletionBookingSagaPublisher.java
+++ b/Booking Service/src/main/java/ba/nwt/bookingservice/saga/UserDeletionBookingSagaPublisher.java
@@ -1,0 +1,28 @@
+package ba.nwt.bookingservice.saga;
+
+import ba.nwt.bookingservice.config.RabbitMQConfig;
+import ba.nwt.bookingservice.saga.event.UserBookingsCancelledEvent;
+import ba.nwt.bookingservice.saga.event.UserBookingsCancellationFailedEvent;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserDeletionBookingSagaPublisher {
+
+    private static final Logger log = LoggerFactory.getLogger(UserDeletionBookingSagaPublisher.class);
+    private final RabbitTemplate rabbitTemplate;
+
+    public void publishBookingsCancelled(UserBookingsCancelledEvent event) {
+        log.info("[SAGA-USER][{}] Publishing UserBookingsCancelledEvent for userId={} count={}", event.getSagaId(), event.getUserId(), event.getCancelledCount());
+        rabbitTemplate.convertAndSend(RabbitMQConfig.SAGA_EXCHANGE, RabbitMQConfig.USER_BOOKINGS_CANCELLED_KEY, event);
+    }
+
+    public void publishBookingsCancellationFailed(UserBookingsCancellationFailedEvent event) {
+        log.warn("[SAGA-USER][{}] Publishing UserBookingsCancellationFailedEvent for userId={}", event.getSagaId(), event.getUserId());
+        rabbitTemplate.convertAndSend(RabbitMQConfig.SAGA_EXCHANGE, RabbitMQConfig.USER_BOOKINGS_FAILED_KEY, event);
+    }
+}

--- a/Booking Service/src/main/java/ba/nwt/bookingservice/saga/event/BookingCancellationRequestedEvent.java
+++ b/Booking Service/src/main/java/ba/nwt/bookingservice/saga/event/BookingCancellationRequestedEvent.java
@@ -1,0 +1,19 @@
+package ba.nwt.bookingservice.saga.event;
+
+import lombok.*;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * Published by Booking Service when a cancellation is requested for a CONFIRMED booking.
+ * Consumed by Payment Service to trigger a refund (local transaction 2).
+ */
+@Data @NoArgsConstructor @AllArgsConstructor @Builder
+public class BookingCancellationRequestedEvent {
+    private String sagaId;
+    private Long bookingId;
+    private Long userId;
+    private BigDecimal refundAmount;
+    private LocalDateTime timestamp;
+    private boolean simulateFailure;
+}

--- a/Booking Service/src/main/java/ba/nwt/bookingservice/saga/event/RefundCompletedEvent.java
+++ b/Booking Service/src/main/java/ba/nwt/bookingservice/saga/event/RefundCompletedEvent.java
@@ -1,0 +1,18 @@
+package ba.nwt.bookingservice.saga.event;
+
+import lombok.*;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * Published by Payment Service when the refund succeeds.
+ * Consumed by Booking Service to finalize cancellation (CANCELLED — final state).
+ */
+@Data @NoArgsConstructor @AllArgsConstructor @Builder
+public class RefundCompletedEvent {
+    private String sagaId;
+    private Long bookingId;
+    private Long paymentId;
+    private BigDecimal refundedAmount;
+    private LocalDateTime timestamp;
+}

--- a/Booking Service/src/main/java/ba/nwt/bookingservice/saga/event/RefundFailedEvent.java
+++ b/Booking Service/src/main/java/ba/nwt/bookingservice/saga/event/RefundFailedEvent.java
@@ -1,0 +1,17 @@
+package ba.nwt.bookingservice.saga.event;
+
+import lombok.*;
+import java.time.LocalDateTime;
+
+/**
+ * Published by Payment Service when the refund fails.
+ * Consumed by Booking Service to execute the compensating action:
+ * restore booking from CANCELLATION_PENDING back to CONFIRMED.
+ */
+@Data @NoArgsConstructor @AllArgsConstructor @Builder
+public class RefundFailedEvent {
+    private String sagaId;
+    private Long bookingId;
+    private String reason;
+    private LocalDateTime timestamp;
+}

--- a/Booking Service/src/main/java/ba/nwt/bookingservice/saga/event/RentalCreatedEvent.java
+++ b/Booking Service/src/main/java/ba/nwt/bookingservice/saga/event/RentalCreatedEvent.java
@@ -1,0 +1,26 @@
+package ba.nwt.bookingservice.saga.event;
+
+import lombok.*;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * Published by Booking Service when a rental is saved as RESERVED.
+ * Consumed by Payment Service to create and process the rental payment (local TX 2).
+ */
+@Data @NoArgsConstructor @AllArgsConstructor @Builder
+public class RentalCreatedEvent {
+    private String sagaId;
+    private Long rentalId;
+    private Long userId;
+    private Long equipmentId;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private Integer quantity;
+    private BigDecimal totalPrice;
+    private BigDecimal depositAmount;
+    private String paymentMethod;
+    private LocalDateTime timestamp;
+    private boolean simulateFailure;
+}

--- a/Booking Service/src/main/java/ba/nwt/bookingservice/saga/event/RentalPaymentCompletedEvent.java
+++ b/Booking Service/src/main/java/ba/nwt/bookingservice/saga/event/RentalPaymentCompletedEvent.java
@@ -1,0 +1,15 @@
+package ba.nwt.bookingservice.saga.event;
+
+import lombok.*;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data @NoArgsConstructor @AllArgsConstructor @Builder
+public class RentalPaymentCompletedEvent {
+    private String sagaId;
+    private Long rentalId;
+    private Long paymentId;
+    private String transactionId;
+    private BigDecimal amount;
+    private LocalDateTime timestamp;
+}

--- a/Booking Service/src/main/java/ba/nwt/bookingservice/saga/event/RentalPaymentFailedEvent.java
+++ b/Booking Service/src/main/java/ba/nwt/bookingservice/saga/event/RentalPaymentFailedEvent.java
@@ -1,0 +1,12 @@
+package ba.nwt.bookingservice.saga.event;
+
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Data @NoArgsConstructor @AllArgsConstructor @Builder
+public class RentalPaymentFailedEvent {
+    private String sagaId;
+    private Long rentalId;
+    private String reason;
+    private LocalDateTime timestamp;
+}

--- a/Booking Service/src/main/java/ba/nwt/bookingservice/saga/event/UserBookingsCancellationFailedEvent.java
+++ b/Booking Service/src/main/java/ba/nwt/bookingservice/saga/event/UserBookingsCancellationFailedEvent.java
@@ -1,0 +1,12 @@
+package ba.nwt.bookingservice.saga.event;
+
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Data @NoArgsConstructor @AllArgsConstructor @Builder
+public class UserBookingsCancellationFailedEvent {
+    private String sagaId;
+    private Long userId;
+    private String reason;
+    private LocalDateTime timestamp;
+}

--- a/Booking Service/src/main/java/ba/nwt/bookingservice/saga/event/UserBookingsCancelledEvent.java
+++ b/Booking Service/src/main/java/ba/nwt/bookingservice/saga/event/UserBookingsCancelledEvent.java
@@ -1,0 +1,12 @@
+package ba.nwt.bookingservice.saga.event;
+
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Data @NoArgsConstructor @AllArgsConstructor @Builder
+public class UserBookingsCancelledEvent {
+    private String sagaId;
+    private Long userId;
+    private int cancelledCount;
+    private LocalDateTime timestamp;
+}

--- a/Booking Service/src/main/java/ba/nwt/bookingservice/saga/event/UserDeletionRequestedEvent.java
+++ b/Booking Service/src/main/java/ba/nwt/bookingservice/saga/event/UserDeletionRequestedEvent.java
@@ -1,0 +1,12 @@
+package ba.nwt.bookingservice.saga.event;
+
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Data @NoArgsConstructor @AllArgsConstructor @Builder
+public class UserDeletionRequestedEvent {
+    private String sagaId;
+    private Long userId;
+    private String username;
+    private LocalDateTime timestamp;
+}

--- a/Booking Service/src/main/java/ba/nwt/bookingservice/service/BookingCancellationSagaService.java
+++ b/Booking Service/src/main/java/ba/nwt/bookingservice/service/BookingCancellationSagaService.java
@@ -1,0 +1,100 @@
+package ba.nwt.bookingservice.service;
+
+import ba.nwt.bookingservice.dto.BookingResponseDTO;
+import ba.nwt.bookingservice.exception.ResourceNotFoundException;
+import ba.nwt.bookingservice.model.Booking;
+import ba.nwt.bookingservice.repository.BookingRepository;
+import ba.nwt.bookingservice.saga.BookingCancellationSagaPublisher;
+import ba.nwt.bookingservice.saga.event.BookingCancellationRequestedEvent;
+import ba.nwt.bookingservice.saga.event.RefundCompletedEvent;
+import ba.nwt.bookingservice.saga.event.RefundFailedEvent;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Booking Cancellation Saga — Booking Service side.
+ *
+ * Steps:
+ *  1. initiate()       — Booking CONFIRMED → CANCELLATION_PENDING  [local TX 1]
+ *                        → publish BookingCancellationRequestedEvent
+ *  2. finalizeCancel() — Booking CANCELLATION_PENDING → CANCELLED   [final state]
+ *  3. restoreBooking() — Booking CANCELLATION_PENDING → CONFIRMED   [compensating — inverse of TX1]
+ */
+@Service
+@RequiredArgsConstructor
+public class BookingCancellationSagaService {
+
+    private static final Logger log = LoggerFactory.getLogger(BookingCancellationSagaService.class);
+
+    private final BookingRepository bookingRepository;
+    private final BookingCancellationSagaPublisher publisher;
+    private final ModelMapper modelMapper;
+
+    /** Local TX 1: mark booking as CANCELLATION_PENDING and trigger refund. */
+    @Transactional
+    public BookingResponseDTO initiate(Long bookingId, boolean simulateFailure) {
+        Booking booking = bookingRepository.findById(bookingId)
+                .orElseThrow(() -> new ResourceNotFoundException("Booking not found id=" + bookingId));
+
+        if (booking.getStatus() != Booking.BookingStatus.CONFIRMED) {
+            throw new IllegalStateException(
+                    "Only CONFIRMED bookings can be cancelled via saga (current: " + booking.getStatus() + ")");
+        }
+
+        String sagaId = UUID.randomUUID().toString();
+        booking.setStatus(Booking.BookingStatus.CANCELLATION_PENDING);
+        bookingRepository.save(booking);
+        log.info("[SAGA-CANCEL][{}] Local TX 1 — Booking id={} → CANCELLATION_PENDING", sagaId, bookingId);
+
+        publisher.publishCancellationRequested(BookingCancellationRequestedEvent.builder()
+                .sagaId(sagaId)
+                .bookingId(bookingId)
+                .userId(booking.getUserId())
+                .refundAmount(booking.getTotalPrice())
+                .simulateFailure(simulateFailure)
+                .timestamp(LocalDateTime.now())
+                .build());
+
+        return modelMapper.map(booking, BookingResponseDTO.class);
+    }
+
+    /** Triggered by RefundCompletedEvent — booking is officially CANCELLED (final state). */
+    @Transactional
+    public void finalizeCancel(RefundCompletedEvent event) {
+        Booking booking = bookingRepository.findById(event.getBookingId())
+                .orElseThrow(() -> new ResourceNotFoundException("Booking not found id=" + event.getBookingId()));
+
+        if (booking.getStatus() != Booking.BookingStatus.CANCELLATION_PENDING) {
+            log.warn("[SAGA-CANCEL][{}] finalizeCancel skipped — booking {} already in {}", event.getSagaId(), event.getBookingId(), booking.getStatus());
+            return;
+        }
+        booking.setStatus(Booking.BookingStatus.CANCELLED);
+        bookingRepository.save(booking);
+        log.info("[SAGA-CANCEL][{}] Booking id={} CANCELLED — saga COMPLETE (refund paymentId={})", event.getSagaId(), event.getBookingId(), event.getPaymentId());
+    }
+
+    /**
+     * Triggered by RefundFailedEvent — compensating (inverse) action.
+     * Restores booking from CANCELLATION_PENDING back to CONFIRMED.
+     */
+    @Transactional
+    public void restoreBooking(RefundFailedEvent event) {
+        Booking booking = bookingRepository.findById(event.getBookingId())
+                .orElseThrow(() -> new ResourceNotFoundException("Booking not found id=" + event.getBookingId()));
+
+        if (booking.getStatus() != Booking.BookingStatus.CANCELLATION_PENDING) {
+            log.warn("[SAGA-CANCEL][{}] restoreBooking skipped — booking {} already in {}", event.getSagaId(), event.getBookingId(), booking.getStatus());
+            return;
+        }
+        booking.setStatus(Booking.BookingStatus.CONFIRMED);
+        bookingRepository.save(booking);
+        log.warn("[SAGA-CANCEL][{}] Booking id={} RESTORED to CONFIRMED (compensating TX) — reason: {}", event.getSagaId(), event.getBookingId(), event.getReason());
+    }
+}

--- a/Booking Service/src/main/java/ba/nwt/bookingservice/service/RentalSagaService.java
+++ b/Booking Service/src/main/java/ba/nwt/bookingservice/service/RentalSagaService.java
@@ -1,0 +1,109 @@
+package ba.nwt.bookingservice.service;
+
+import ba.nwt.bookingservice.dto.EquipmentRentalRequestDTO;
+import ba.nwt.bookingservice.dto.EquipmentRentalResponseDTO;
+import ba.nwt.bookingservice.exception.ResourceNotFoundException;
+import ba.nwt.bookingservice.model.EquipmentRental;
+import ba.nwt.bookingservice.repository.EquipmentRentalRepository;
+import ba.nwt.bookingservice.saga.RentalSagaPublisher;
+import ba.nwt.bookingservice.saga.event.RentalCreatedEvent;
+import ba.nwt.bookingservice.saga.event.RentalPaymentCompletedEvent;
+import ba.nwt.bookingservice.saga.event.RentalPaymentFailedEvent;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Equipment Rental Saga — Booking Service side.
+ *
+ * Steps:
+ *  1. initiate()      — EquipmentRental saved as RESERVED  [local TX 1]
+ *                       → publish RentalCreatedEvent
+ *  2. confirmRental() — rental stays RESERVED (payment confirmed) [final state]
+ *  3. cancelRental()  — rental → CANCELLED  [compensating / inverse of TX1]
+ */
+@Service
+@RequiredArgsConstructor
+public class RentalSagaService {
+
+    private static final Logger log = LoggerFactory.getLogger(RentalSagaService.class);
+
+    private final EquipmentRentalRepository rentalRepository;
+    private final RentalSagaPublisher publisher;
+    private final ModelMapper modelMapper;
+
+    @Transactional
+    public EquipmentRentalResponseDTO initiate(EquipmentRentalRequestDTO dto, String paymentMethod, boolean simulateFailure) {
+        if (!dto.getEndDate().isAfter(dto.getStartDate())) {
+            throw new IllegalArgumentException("End date must be after start date");
+        }
+
+        String sagaId = UUID.randomUUID().toString();
+
+        EquipmentRental rental = rentalRepository.save(EquipmentRental.builder()
+                .userId(dto.getUserId())
+                .equipmentId(dto.getEquipmentId())
+                .startDate(dto.getStartDate())
+                .endDate(dto.getEndDate())
+                .quantity(dto.getQuantity() != null ? dto.getQuantity() : 1)
+                .totalPrice(dto.getTotalPrice())
+                .depositPaid(dto.getDepositPaid() != null ? dto.getDepositPaid() : java.math.BigDecimal.ZERO)
+                .status(EquipmentRental.RentalStatus.RESERVED)
+                .build());
+
+        log.info("[SAGA-RENTAL][{}] Local TX 1 — Rental id={} saved as RESERVED", sagaId, rental.getId());
+
+        publisher.publishRentalCreated(RentalCreatedEvent.builder()
+                .sagaId(sagaId)
+                .rentalId(rental.getId())
+                .userId(rental.getUserId())
+                .equipmentId(rental.getEquipmentId())
+                .startDate(rental.getStartDate())
+                .endDate(rental.getEndDate())
+                .quantity(rental.getQuantity())
+                .totalPrice(rental.getTotalPrice())
+                .depositAmount(rental.getDepositPaid())
+                .paymentMethod(paymentMethod == null ? "CREDIT_CARD" : paymentMethod)
+                .simulateFailure(simulateFailure)
+                .timestamp(LocalDateTime.now())
+                .build());
+
+        return modelMapper.map(rental, EquipmentRentalResponseDTO.class);
+    }
+
+    /** Payment succeeded — rental is confirmed (stays RESERVED, payment done). */
+    @Transactional
+    public void confirmRental(RentalPaymentCompletedEvent event) {
+        EquipmentRental rental = rentalRepository.findById(event.getRentalId())
+                .orElseThrow(() -> new ResourceNotFoundException("Rental not found id=" + event.getRentalId()));
+
+        if (rental.getStatus() != EquipmentRental.RentalStatus.RESERVED) {
+            log.warn("[SAGA-RENTAL][{}] confirmRental skipped — rental {} already in {}", event.getSagaId(), event.getRentalId(), rental.getStatus());
+            return;
+        }
+        // Rental stays RESERVED — payment confirmed, ready for pickup. This is the final state.
+        rentalRepository.save(rental);
+        log.info("[SAGA-RENTAL][{}] Rental id={} CONFIRMED — saga COMPLETE (paymentId={} txn={})", event.getSagaId(), event.getRentalId(), event.getPaymentId(), event.getTransactionId());
+    }
+
+    /** Payment failed — compensating action: cancel the rental. */
+    @Transactional
+    public void cancelRental(RentalPaymentFailedEvent event) {
+        EquipmentRental rental = rentalRepository.findById(event.getRentalId())
+                .orElseThrow(() -> new ResourceNotFoundException("Rental not found id=" + event.getRentalId()));
+
+        if (rental.getStatus() != EquipmentRental.RentalStatus.RESERVED) {
+            log.warn("[SAGA-RENTAL][{}] cancelRental skipped — rental {} already in {}", event.getSagaId(), event.getRentalId(), rental.getStatus());
+            return;
+        }
+        rental.setStatus(EquipmentRental.RentalStatus.CANCELLED);
+        rentalRepository.save(rental);
+        log.warn("[SAGA-RENTAL][{}] Rental id={} CANCELLED (compensating TX) — reason: {}", event.getSagaId(), event.getRentalId(), event.getReason());
+    }
+}

--- a/Booking Service/src/main/java/ba/nwt/bookingservice/service/UserDeletionBookingSagaService.java
+++ b/Booking Service/src/main/java/ba/nwt/bookingservice/service/UserDeletionBookingSagaService.java
@@ -1,0 +1,65 @@
+package ba.nwt.bookingservice.service;
+
+import ba.nwt.bookingservice.model.Booking;
+import ba.nwt.bookingservice.repository.BookingRepository;
+import ba.nwt.bookingservice.saga.UserDeletionBookingSagaPublisher;
+import ba.nwt.bookingservice.saga.event.UserBookingsCancelledEvent;
+import ba.nwt.bookingservice.saga.event.UserBookingsCancellationFailedEvent;
+import ba.nwt.bookingservice.saga.event.UserDeletionRequestedEvent;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * User Deletion Saga — Booking Service side.
+ *
+ * Local TX 2: cancel all PENDING/CONFIRMED bookings for the given userId.
+ * On success → publish UserBookingsCancelledEvent → User finalized as DELETED.
+ * On failure → publish UserBookingsCancellationFailedEvent → User restored to ACTIVE.
+ */
+@Service
+@RequiredArgsConstructor
+public class UserDeletionBookingSagaService {
+
+    private static final Logger log = LoggerFactory.getLogger(UserDeletionBookingSagaService.class);
+
+    private final BookingRepository bookingRepository;
+    private final UserDeletionBookingSagaPublisher publisher;
+
+    private static final List<Booking.BookingStatus> ACTIVE_STATUSES =
+            List.of(Booking.BookingStatus.PENDING, Booking.BookingStatus.CONFIRMED, Booking.BookingStatus.CANCELLATION_PENDING);
+
+    @Transactional
+    public void cancelUserBookings(UserDeletionRequestedEvent event) {
+        log.info("[SAGA-USER][{}] Local TX 2 start — cancelling bookings for userId={}", event.getSagaId(), event.getUserId());
+
+        try {
+            List<Booking> activeBookings = bookingRepository.findByUserIdAndStatusIn(event.getUserId(), ACTIVE_STATUSES);
+
+            activeBookings.forEach(b -> b.setStatus(Booking.BookingStatus.CANCELLED));
+            bookingRepository.saveAll(activeBookings);
+
+            log.info("[SAGA-USER][{}] Cancelled {} bookings for userId={}", event.getSagaId(), activeBookings.size(), event.getUserId());
+
+            publisher.publishBookingsCancelled(UserBookingsCancelledEvent.builder()
+                    .sagaId(event.getSagaId())
+                    .userId(event.getUserId())
+                    .cancelledCount(activeBookings.size())
+                    .timestamp(LocalDateTime.now())
+                    .build());
+        } catch (Exception ex) {
+            log.error("[SAGA-USER][{}] Failed to cancel bookings for userId={}: {}", event.getSagaId(), event.getUserId(), ex.getMessage());
+            publisher.publishBookingsCancellationFailed(UserBookingsCancellationFailedEvent.builder()
+                    .sagaId(event.getSagaId())
+                    .userId(event.getUserId())
+                    .reason("Failed to cancel bookings: " + ex.getMessage())
+                    .timestamp(LocalDateTime.now())
+                    .build());
+        }
+    }
+}

--- a/Booking Service/src/test/java/ba/nwt/bookingservice/saga/BookingCancellationSagaServiceTest.java
+++ b/Booking Service/src/test/java/ba/nwt/bookingservice/saga/BookingCancellationSagaServiceTest.java
@@ -1,0 +1,140 @@
+package ba.nwt.bookingservice.saga;
+
+import ba.nwt.bookingservice.exception.ResourceNotFoundException;
+import ba.nwt.bookingservice.model.Booking;
+import ba.nwt.bookingservice.repository.BookingRepository;
+import ba.nwt.bookingservice.saga.event.RefundCompletedEvent;
+import ba.nwt.bookingservice.saga.event.RefundFailedEvent;
+import ba.nwt.bookingservice.service.BookingCancellationSagaService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.modelmapper.ModelMapper;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class BookingCancellationSagaServiceTest {
+
+    @Mock BookingRepository bookingRepository;
+    @Mock BookingCancellationSagaPublisher publisher;
+    @Mock ModelMapper modelMapper;
+    @InjectMocks BookingCancellationSagaService service;
+
+    private Booking confirmedBooking;
+
+    @BeforeEach
+    void setUp() {
+        confirmedBooking = Booking.builder()
+                .id(10L).userId(1L).facilityId(2L)
+                .startTime(LocalDateTime.now().plusDays(1))
+                .endTime(LocalDateTime.now().plusDays(1).plusHours(2))
+                .totalPrice(new BigDecimal("150.00"))
+                .status(Booking.BookingStatus.CONFIRMED)
+                .build();
+    }
+
+    // ── initiate() ────────────────────────────────────────────────────────────
+
+    @Test
+    void initiate_setsBookingToCancellationPending_andPublishesEvent() {
+        when(bookingRepository.findById(10L)).thenReturn(Optional.of(confirmedBooking));
+        when(bookingRepository.save(any())).thenReturn(confirmedBooking);
+        when(modelMapper.map(any(), any())).thenReturn(null);
+
+        service.initiate(10L, false);
+
+        ArgumentCaptor<Booking> captor = ArgumentCaptor.forClass(Booking.class);
+        verify(bookingRepository).save(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(Booking.BookingStatus.CANCELLATION_PENDING);
+
+        verify(publisher).publishCancellationRequested(argThat(e ->
+                e.getBookingId().equals(10L) && !e.isSimulateFailure()));
+    }
+
+    @Test
+    void initiate_withSimulateFailure_passesFlag() {
+        when(bookingRepository.findById(10L)).thenReturn(Optional.of(confirmedBooking));
+        when(bookingRepository.save(any())).thenReturn(confirmedBooking);
+        when(modelMapper.map(any(), any())).thenReturn(null);
+
+        service.initiate(10L, true);
+
+        verify(publisher).publishCancellationRequested(argThat(e -> e.isSimulateFailure()));
+    }
+
+    @Test
+    void initiate_throwsIllegalState_whenBookingNotConfirmed() {
+        confirmedBooking.setStatus(Booking.BookingStatus.PENDING);
+        when(bookingRepository.findById(10L)).thenReturn(Optional.of(confirmedBooking));
+
+        assertThatThrownBy(() -> service.initiate(10L, false))
+                .isInstanceOf(IllegalStateException.class);
+        verifyNoInteractions(publisher);
+    }
+
+    @Test
+    void initiate_throwsResourceNotFound_whenBookingMissing() {
+        when(bookingRepository.findById(99L)).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> service.initiate(99L, false)).isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    // ── finalizeCancel() ──────────────────────────────────────────────────────
+
+    @Test
+    void finalizeCancel_setsBookingToCancelled_finalState() {
+        confirmedBooking.setStatus(Booking.BookingStatus.CANCELLATION_PENDING);
+        when(bookingRepository.findById(10L)).thenReturn(Optional.of(confirmedBooking));
+        when(bookingRepository.save(any())).thenReturn(confirmedBooking);
+
+        service.finalizeCancel(RefundCompletedEvent.builder()
+                .sagaId("s1").bookingId(10L).paymentId(5L)
+                .refundedAmount(BigDecimal.TEN).timestamp(LocalDateTime.now()).build());
+
+        ArgumentCaptor<Booking> captor = ArgumentCaptor.forClass(Booking.class);
+        verify(bookingRepository).save(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(Booking.BookingStatus.CANCELLED);
+    }
+
+    @Test
+    void finalizeCancel_isIdempotent_whenAlreadyCancelled() {
+        confirmedBooking.setStatus(Booking.BookingStatus.CANCELLED);
+        when(bookingRepository.findById(10L)).thenReturn(Optional.of(confirmedBooking));
+
+        service.finalizeCancel(RefundCompletedEvent.builder().sagaId("s").bookingId(10L).build());
+        verify(bookingRepository, never()).save(any());
+    }
+
+    // ── restoreBooking() (compensating) ───────────────────────────────────────
+
+    @Test
+    void restoreBooking_compensatingAction_restoresToConfirmed() {
+        confirmedBooking.setStatus(Booking.BookingStatus.CANCELLATION_PENDING);
+        when(bookingRepository.findById(10L)).thenReturn(Optional.of(confirmedBooking));
+        when(bookingRepository.save(any())).thenReturn(confirmedBooking);
+
+        service.restoreBooking(RefundFailedEvent.builder()
+                .sagaId("s1").bookingId(10L).reason("no payment found").timestamp(LocalDateTime.now()).build());
+
+        ArgumentCaptor<Booking> captor = ArgumentCaptor.forClass(Booking.class);
+        verify(bookingRepository).save(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(Booking.BookingStatus.CONFIRMED);
+    }
+
+    @Test
+    void restoreBooking_isIdempotent_whenAlreadyConfirmed() {
+        when(bookingRepository.findById(10L)).thenReturn(Optional.of(confirmedBooking));
+        service.restoreBooking(RefundFailedEvent.builder().sagaId("s").bookingId(10L).reason("dup").build());
+        verify(bookingRepository, never()).save(any());
+    }
+}

--- a/Booking Service/src/test/java/ba/nwt/bookingservice/saga/RentalSagaServiceTest.java
+++ b/Booking Service/src/test/java/ba/nwt/bookingservice/saga/RentalSagaServiceTest.java
@@ -1,0 +1,150 @@
+package ba.nwt.bookingservice.saga;
+
+import ba.nwt.bookingservice.dto.EquipmentRentalRequestDTO;
+import ba.nwt.bookingservice.exception.ResourceNotFoundException;
+import ba.nwt.bookingservice.model.EquipmentRental;
+import ba.nwt.bookingservice.repository.EquipmentRentalRepository;
+import ba.nwt.bookingservice.saga.event.RentalPaymentCompletedEvent;
+import ba.nwt.bookingservice.saga.event.RentalPaymentFailedEvent;
+import ba.nwt.bookingservice.service.RentalSagaService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.modelmapper.ModelMapper;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RentalSagaServiceTest {
+
+    @Mock EquipmentRentalRepository rentalRepository;
+    @Mock RentalSagaPublisher publisher;
+    @Mock ModelMapper modelMapper;
+    @InjectMocks RentalSagaService service;
+
+    private EquipmentRentalRequestDTO validRequest;
+    private EquipmentRental savedRental;
+
+    @BeforeEach
+    void setUp() {
+        validRequest = EquipmentRentalRequestDTO.builder()
+                .userId(1L).equipmentId(5L)
+                .startDate(LocalDate.now().plusDays(1))
+                .endDate(LocalDate.now().plusDays(3))
+                .quantity(1)
+                .totalPrice(new BigDecimal("50.00"))
+                .build();
+
+        savedRental = EquipmentRental.builder()
+                .id(20L).userId(1L).equipmentId(5L)
+                .startDate(validRequest.getStartDate())
+                .endDate(validRequest.getEndDate())
+                .quantity(1)
+                .totalPrice(new BigDecimal("50.00"))
+                .status(EquipmentRental.RentalStatus.RESERVED)
+                .build();
+    }
+
+    // ── initiate() ────────────────────────────────────────────────────────────
+
+    @Test
+    void initiate_savesRentalAsReserved_andPublishesEvent() {
+        when(rentalRepository.save(any())).thenReturn(savedRental);
+        when(modelMapper.map(any(), any())).thenReturn(null);
+
+        service.initiate(validRequest, "CREDIT_CARD", false);
+
+        ArgumentCaptor<EquipmentRental> captor = ArgumentCaptor.forClass(EquipmentRental.class);
+        verify(rentalRepository).save(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(EquipmentRental.RentalStatus.RESERVED);
+
+        verify(publisher).publishRentalCreated(argThat(e ->
+                e.getRentalId().equals(20L) && !e.isSimulateFailure()));
+    }
+
+    @Test
+    void initiate_withSimulateFailure_passesFlag() {
+        when(rentalRepository.save(any())).thenReturn(savedRental);
+        when(modelMapper.map(any(), any())).thenReturn(null);
+
+        service.initiate(validRequest, "DEBIT_CARD", true);
+
+        verify(publisher).publishRentalCreated(argThat(e -> e.isSimulateFailure()));
+    }
+
+    @Test
+    void initiate_throwsIllegalArgument_whenEndDateBeforeStartDate() {
+        validRequest.setEndDate(validRequest.getStartDate().minusDays(1));
+        assertThatThrownBy(() -> service.initiate(validRequest, "CREDIT_CARD", false))
+                .isInstanceOf(IllegalArgumentException.class);
+        verifyNoInteractions(publisher);
+    }
+
+    // ── confirmRental() ───────────────────────────────────────────────────────
+
+    @Test
+    void confirmRental_finalState_rentalStaysReserved() {
+        when(rentalRepository.findById(20L)).thenReturn(Optional.of(savedRental));
+        when(rentalRepository.save(any())).thenReturn(savedRental);
+
+        service.confirmRental(RentalPaymentCompletedEvent.builder()
+                .sagaId("s").rentalId(20L).paymentId(1L)
+                .transactionId("TXN-RENTAL-ABC").amount(BigDecimal.TEN).timestamp(LocalDateTime.now()).build());
+
+        ArgumentCaptor<EquipmentRental> captor = ArgumentCaptor.forClass(EquipmentRental.class);
+        verify(rentalRepository).save(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(EquipmentRental.RentalStatus.RESERVED);
+    }
+
+    @Test
+    void confirmRental_isIdempotent_whenAlreadyActive() {
+        savedRental.setStatus(EquipmentRental.RentalStatus.ACTIVE);
+        when(rentalRepository.findById(20L)).thenReturn(Optional.of(savedRental));
+
+        service.confirmRental(RentalPaymentCompletedEvent.builder().sagaId("s").rentalId(20L).build());
+        verify(rentalRepository, never()).save(any());
+    }
+
+    @Test
+    void confirmRental_throwsResourceNotFound_whenRentalMissing() {
+        when(rentalRepository.findById(99L)).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> service.confirmRental(
+                RentalPaymentCompletedEvent.builder().sagaId("s").rentalId(99L).build()))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    // ── cancelRental() (compensating) ─────────────────────────────────────────
+
+    @Test
+    void cancelRental_compensatingAction_setsRentalToCancelled() {
+        when(rentalRepository.findById(20L)).thenReturn(Optional.of(savedRental));
+        when(rentalRepository.save(any())).thenReturn(savedRental);
+
+        service.cancelRental(RentalPaymentFailedEvent.builder()
+                .sagaId("s").rentalId(20L).reason("card declined").timestamp(LocalDateTime.now()).build());
+
+        ArgumentCaptor<EquipmentRental> captor = ArgumentCaptor.forClass(EquipmentRental.class);
+        verify(rentalRepository).save(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(EquipmentRental.RentalStatus.CANCELLED);
+    }
+
+    @Test
+    void cancelRental_isIdempotent_whenAlreadyCancelled() {
+        savedRental.setStatus(EquipmentRental.RentalStatus.CANCELLED);
+        when(rentalRepository.findById(20L)).thenReturn(Optional.of(savedRental));
+
+        service.cancelRental(RentalPaymentFailedEvent.builder().sagaId("s").rentalId(20L).reason("dup").build());
+        verify(rentalRepository, never()).save(any());
+    }
+}

--- a/Booking Service/src/test/java/ba/nwt/bookingservice/saga/UserDeletionBookingSagaServiceTest.java
+++ b/Booking Service/src/test/java/ba/nwt/bookingservice/saga/UserDeletionBookingSagaServiceTest.java
@@ -1,0 +1,101 @@
+package ba.nwt.bookingservice.saga;
+
+import ba.nwt.bookingservice.model.Booking;
+import ba.nwt.bookingservice.repository.BookingRepository;
+import ba.nwt.bookingservice.saga.event.UserDeletionRequestedEvent;
+import ba.nwt.bookingservice.service.UserDeletionBookingSagaService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserDeletionBookingSagaServiceTest {
+
+    @Mock BookingRepository bookingRepository;
+    @Mock UserDeletionBookingSagaPublisher publisher;
+    @InjectMocks UserDeletionBookingSagaService service;
+
+    private UserDeletionRequestedEvent buildEvent() {
+        return UserDeletionRequestedEvent.builder()
+                .sagaId("saga-user-01").userId(1L).username("test_user")
+                .timestamp(LocalDateTime.now()).build();
+    }
+
+    private Booking buildBooking(Long id, Booking.BookingStatus status) {
+        return Booking.builder().id(id).userId(1L).facilityId(2L)
+                .startTime(LocalDateTime.now().plusDays(1))
+                .endTime(LocalDateTime.now().plusDays(1).plusHours(2))
+                .totalPrice(new BigDecimal("100.00"))
+                .status(status).build();
+    }
+
+    // ── cancelUserBookings() happy path ───────────────────────────────────────
+
+    @Test
+    void cancelUserBookings_cancelsAllActiveBookings_andPublishesSuccess() {
+        List<Booking> active = List.of(
+                buildBooking(1L, Booking.BookingStatus.PENDING),
+                buildBooking(2L, Booking.BookingStatus.CONFIRMED));
+
+        when(bookingRepository.findByUserIdAndStatusIn(eq(1L), anyList())).thenReturn(active);
+        when(bookingRepository.saveAll(anyList())).thenReturn(active);
+
+        service.cancelUserBookings(buildEvent());
+
+        verify(bookingRepository).saveAll(argThat(bookings ->
+                ((List<Booking>) bookings).stream()
+                        .allMatch(b -> b.getStatus() == Booking.BookingStatus.CANCELLED)));
+
+        verify(publisher).publishBookingsCancelled(argThat(e ->
+                e.getUserId().equals(1L) && e.getCancelledCount() == 2));
+        verify(publisher, never()).publishBookingsCancellationFailed(any());
+    }
+
+    @Test
+    void cancelUserBookings_withZeroBookings_publishesSuccessWithZeroCount() {
+        when(bookingRepository.findByUserIdAndStatusIn(eq(1L), anyList())).thenReturn(List.of());
+        when(bookingRepository.saveAll(anyList())).thenReturn(List.of());
+
+        service.cancelUserBookings(buildEvent());
+
+        verify(publisher).publishBookingsCancelled(argThat(e -> e.getCancelledCount() == 0));
+        verify(publisher, never()).publishBookingsCancellationFailed(any());
+    }
+
+    // ── cancelUserBookings() failure / compensating path ─────────────────────
+
+    @Test
+    void cancelUserBookings_onException_publishesFailedEvent() {
+        when(bookingRepository.findByUserIdAndStatusIn(eq(1L), anyList()))
+                .thenThrow(new RuntimeException("DB timeout"));
+
+        service.cancelUserBookings(buildEvent());
+
+        verify(publisher).publishBookingsCancellationFailed(argThat(e ->
+                e.getUserId().equals(1L) && e.getReason().contains("DB timeout")));
+        verify(publisher, never()).publishBookingsCancelled(any());
+    }
+
+    @Test
+    void cancelUserBookings_sagaIdPropagatedToEvent() {
+        when(bookingRepository.findByUserIdAndStatusIn(eq(1L), anyList())).thenReturn(List.of());
+        when(bookingRepository.saveAll(anyList())).thenReturn(List.of());
+
+        service.cancelUserBookings(buildEvent());
+
+        verify(publisher).publishBookingsCancelled(argThat(e -> "saga-user-01".equals(e.getSagaId())));
+    }
+}

--- a/IZVJESTAJ_ASYNC_KOMUNIKACIJA.md
+++ b/IZVJESTAJ_ASYNC_KOMUNIKACIJA.md
@@ -1,0 +1,662 @@
+# Asinkrona komunikacija — RabbitMQ Saga Choreography
+## Kompletna dokumentacija svih implementiranih saga
+
+> **Projekt:** SportsCenterSystem  
+> **Tehnologije:** Spring Boot 3.2.5 · Spring AMQP · RabbitMQ 3.13 · Java 17
+
+---
+
+## SADRŽAJ
+
+1. [Pregled — šta je implementirano](#1-pregled)
+2. [Infrastruktura: RabbitMQ Exchange i Queues](#2-infrastruktura)
+3. [Saga 1 — Kreiranje rezervacije + Plaćanje](#3-saga-1--kreiranje-rezervacije--plaćanje)
+4. [Saga 2 — Otkazivanje rezervacije + Refund](#4-saga-2--otkazivanje-rezervacije--refund)
+5. [Saga 3 — Najam opreme + Plaćanje](#5-saga-3--najam-opreme--plaćanje)
+6. [Saga 4 — Brisanje korisnika + Kaskadni cancel bookinga](#6-saga-4--brisanje-korisnika--kaskadni-cancel-bookinga)
+7. [Mapa svih fajlova](#7-mapa-svih-fajlova)
+8. [Testovi — pregled svih test klasa](#8-testovi)
+9. [Live testiranje — curl komande](#9-live-testiranje)
+10. [Dijagrami svih saga](#10-dijagrami)
+
+---
+
+## 1. Pregled
+
+Implementirane su **4 Saga Choreography** instance koje pokrivaju sve glavne scenarije cross-service koordinacije:
+
+| # | Saga | Servisi | TX1 | TX2 | Kompenzacija |
+|---|---|---|---|---|---|
+| 1 | Kreiranje rezervacije | Booking ↔ Payment | Booking → PENDING | Payment → PAID | Booking → CANCELLED |
+| 2 | Otkazivanje rezervacije | Booking ↔ Payment | Booking → CANCELLATION_PENDING | Payment → REFUNDED | Booking → CONFIRMED (restore) |
+| 3 | Najam opreme | Booking ↔ Payment | EquipmentRental → RESERVED | Payment → PAID | Rental → CANCELLED |
+| 4 | Brisanje korisnika | User ↔ Booking | User → DELETION_PENDING | Bookings → CANCELLED | User → ACTIVE (restore) |
+
+Sve sage koriste **isti Topic Exchange** (`sportcenter.saga.exchange`) sa 12 durable queueova.
+
+---
+
+## 2. Infrastruktura
+
+### Exchange
+
+```
+sportcenter.saga.exchange  (Topic Exchange, durable=true)
+```
+
+### Svih 12 Queueova
+
+| Queue | Routing Key | Producer | Consumer |
+|---|---|---|---|
+| `sportcenter.booking.created.queue` | `booking.saga.created` | Booking | Payment |
+| `sportcenter.payment.completed.queue` | `payment.saga.completed` | Payment | Booking |
+| `sportcenter.payment.failed.queue` | `payment.saga.failed` | Payment | Booking |
+| `sportcenter.booking.cancellation.queue` | `booking.saga.cancellation` | Booking | Payment |
+| `sportcenter.refund.completed.queue` | `refund.saga.completed` | Payment | Booking |
+| `sportcenter.refund.failed.queue` | `refund.saga.failed` | Payment | Booking |
+| `sportcenter.rental.created.queue` | `rental.saga.created` | Booking | Payment |
+| `sportcenter.rental.payment.completed.queue` | `rental.payment.saga.completed` | Payment | Booking |
+| `sportcenter.rental.payment.failed.queue` | `rental.payment.saga.failed` | Payment | Booking |
+| `sportcenter.user.deletion.queue` | `user.saga.deletion` | User | Booking |
+| `sportcenter.user.bookings.cancelled.queue` | `user.saga.bookings.cancelled` | Booking | User |
+| `sportcenter.user.bookings.failed.queue` | `user.saga.bookings.failed` | Booking | User |
+
+### Konfiguracija servisa
+
+Svaki servis ima `RabbitMQConfig.java` koji:
+- Deklarira sve relevantne Queues (durable)
+- Deklarira Bindings prema Exchange-u
+- Registruje `Jackson2JsonMessageConverter` sa Spring Boot-ovim `ObjectMapper` (JavaTimeModule uključen)
+- Postavlja `TypePrecedence.INFERRED` — koristi tip parametra `@RabbitListener` metode za deserijalizaciju umjesto `__TypeId__` headera (riješava cross-service class-not-found problem)
+
+---
+
+## 3. Saga 1 — Kreiranje rezervacije + Plaćanje
+
+### Endpoint
+```
+POST /api/bookings/saga
+POST /api/bookings/saga?simulateFailure=true   ← testira kompenzaciju
+```
+
+### Stanja
+```
+Booking: PENDING → CONFIRMED   (sretni put — finalno)
+Booking: PENDING → CANCELLED   (kompenzacija)
+Payment: PENDING → PAID        (sretni put)
+Payment: PENDING → FAILED      (greška)
+```
+
+### Dijagram toka
+
+```
+Klijent                 Booking Service              RabbitMQ              Payment Service
+  │                         │                            │                       │
+  │──POST /saga────────────→│                            │                       │
+  │                         │                            │                       │
+  │              ┌──────────┴──────┐                    │                       │
+  │              │  LOCAL TX 1     │                    │                       │
+  │              │ Booking→PENDING │                    │                       │
+  │              └──────────┬──────┘                    │                       │
+  │                         │──BookingCreatedEvent──────→│──────────────────────→│
+  │◄──202 Accepted──────────│                            │                       │
+  │                         │                            │        ┌──────────────┴──────────┐
+  │                         │                            │        │      LOCAL TX 2          │
+  │                         │                            │        │  Payment→PENDING→PAID    │
+  │                         │                            │        └──────────────┬──────────┘
+  │                         │◄──PaymentCompletedEvent───│◄──────────────────────│
+  │              ┌──────────┴──────┐                    │                       │
+  │              │ Booking→CONFIRMED (FINALNO)           │                       │
+  │              └─────────────────┘                    │                       │
+  │
+  │  [ AKO PAYMENT PADNE ]
+  │                         │◄──PaymentFailedEvent──────│◄──────────────────────│
+  │              ┌──────────┴──────┐                    │                       │
+  │              │ Booking→CANCELLED (KOMPENZACIJA)      │                       │
+  │              └─────────────────┘                    │                       │
+```
+
+### Ključne klase
+
+| Servis | Klasa | Uloga |
+|---|---|---|
+| Booking | `BookingSagaService` | TX1: save PENDING, initiate(), confirmBooking(), cancelBooking() |
+| Booking | `BookingSagaPublisher` | Šalje BookingCreatedEvent |
+| Booking | `BookingSagaConsumer` | Prima PaymentCompleted/Failed |
+| Payment | `PaymentSagaService` | TX2: save PENDING→PAID/FAILED |
+| Payment | `PaymentSagaPublisher` | Šalje PaymentCompleted/Failed |
+| Payment | `PaymentSagaConsumer` | Prima BookingCreatedEvent |
+
+---
+
+## 4. Saga 2 — Otkazivanje rezervacije + Refund
+
+### Endpoint
+```
+POST /api/bookings/{id}/cancel
+POST /api/bookings/{id}/cancel?simulateFailure=true   ← testira kompenzaciju
+```
+
+### Stanja
+```
+Booking: CONFIRMED → CANCELLATION_PENDING → CANCELLED   (sretni put — finalno)
+Booking: CONFIRMED → CANCELLATION_PENDING → CONFIRMED   (kompenzacija — restore)
+Payment: PAID → REFUNDED                                 (sretni put)
+```
+
+**Ovo je inverz Sage 1** — isti pattern ali u suprotnom smjeru.
+
+### Dijagram toka
+
+```
+Klijent                 Booking Service              RabbitMQ              Payment Service
+  │                         │                            │                       │
+  │──POST /{id}/cancel─────→│                            │                       │
+  │                         │                            │                       │
+  │              ┌──────────┴──────┐                    │                       │
+  │              │  LOCAL TX 1     │                    │                       │
+  │              │ CONFIRMED →     │                    │                       │
+  │              │ CANCELLATION_   │                    │                       │
+  │              │ PENDING         │                    │                       │
+  │              └──────────┬──────┘                    │                       │
+  │                         │──BookingCancellation──────→│──────────────────────→│
+  │                         │    RequestedEvent          │                       │
+  │◄──202 Accepted──────────│                            │                       │
+  │                         │                            │        ┌──────────────┴──────────┐
+  │                         │                            │        │      LOCAL TX 2          │
+  │                         │                            │        │  PAID → REFUNDED         │
+  │                         │                            │        └──────────────┬──────────┘
+  │                         │◄──RefundCompletedEvent────│◄──────────────────────│
+  │              ┌──────────┴──────┐                    │                       │
+  │              │ CANCELLATION_PENDING → CANCELLED     │                       │
+  │              │ (FINALNO)             │              │                       │
+  │              └─────────────────┘                    │                       │
+  │
+  │  [ AKO REFUND PADNE — KOMPENZACIJA ]
+  │                         │◄──RefundFailedEvent───────│◄──────────────────────│
+  │              ┌──────────┴──────┐                    │                       │
+  │              │ CANCELLATION_PENDING → CONFIRMED     │                       │
+  │              │ (RESTORE — INVERZNA AKCIJA)          │                       │
+  │              └─────────────────┘                    │                       │
+```
+
+### Ključne klase
+
+| Servis | Klasa | Uloga |
+|---|---|---|
+| Booking | `BookingCancellationSagaService` | TX1: CONFIRMED→CANCELLATION_PENDING, finalizeCancel(), restoreBooking() |
+| Booking | `BookingCancellationSagaPublisher` | Šalje BookingCancellationRequestedEvent |
+| Booking | `BookingCancellationSagaConsumer` | Prima RefundCompleted/Failed |
+| Payment | `RefundSagaService` | TX2: PAID→REFUNDED ili greška |
+| Payment | `RefundSagaPublisher` | Šalje RefundCompleted/Failed |
+| Payment | `RefundSagaConsumer` | Prima BookingCancellationRequestedEvent |
+
+---
+
+## 5. Saga 3 — Najam opreme + Plaćanje
+
+### Endpoint
+```
+POST /api/rentals/saga
+POST /api/rentals/saga?simulateFailure=true   ← testira kompenzaciju
+```
+
+### Stanja
+```
+EquipmentRental: RESERVED (platno, spreman za preuzimanje)   (finalno)
+EquipmentRental: RESERVED → CANCELLED                        (kompenzacija)
+Payment:         PENDING → PAID                               (sretni put)
+Payment:         PENDING → FAILED                             (greška)
+```
+
+### Dijagram toka
+
+```
+Klijent                 Booking Service              RabbitMQ              Payment Service
+  │                         │                            │                       │
+  │──POST /rentals/saga────→│                            │                       │
+  │                         │                            │                       │
+  │              ┌──────────┴──────┐                    │                       │
+  │              │  LOCAL TX 1     │                    │                       │
+  │              │ Rental→RESERVED │                    │                       │
+  │              └──────────┬──────┘                    │                       │
+  │                         │──RentalCreatedEvent───────→│──────────────────────→│
+  │◄──202 Accepted──────────│                            │                       │
+  │                         │                            │        ┌──────────────┴──────────┐
+  │                         │                            │        │      LOCAL TX 2          │
+  │                         │                            │        │  Payment→PENDING→PAID    │
+  │                         │                            │        └──────────────┬──────────┘
+  │                         │◄──RentalPayment────────────│◄──────────────────────│
+  │                         │    CompletedEvent          │                       │
+  │              ┌──────────┴──────┐                    │                       │
+  │              │ Rental ostaje   │                    │                       │
+  │              │ RESERVED        │                    │                       │
+  │              │ (FINALNO)       │                    │                       │
+  │              └─────────────────┘                    │                       │
+  │
+  │  [ AKO PAYMENT PADNE — KOMPENZACIJA ]
+  │                         │◄──RentalPaymentFailed─────│◄──────────────────────│
+  │              ┌──────────┴──────┐                    │                       │
+  │              │ Rental→CANCELLED│                    │                       │
+  │              │ (INVERZNA AKCIJA)                    │                       │
+  │              └─────────────────┘                    │                       │
+```
+
+### Ključne klase
+
+| Servis | Klasa | Uloga |
+|---|---|---|
+| Booking | `RentalSagaService` | TX1: save RESERVED, confirmRental(), cancelRental() |
+| Booking | `RentalSagaPublisher` | Šalje RentalCreatedEvent |
+| Booking | `RentalSagaConsumer` | Prima RentalPaymentCompleted/Failed |
+| Payment | `RentalPaymentSagaService` | TX2: PENDING→PAID/FAILED za rental |
+| Payment | `RentalPaymentSagaPublisher` | Šalje RentalPaymentCompleted/Failed |
+| Payment | `RentalPaymentSagaConsumer` | Prima RentalCreatedEvent |
+
+---
+
+## 6. Saga 4 — Brisanje korisnika + Kaskadni cancel bookinga
+
+### Endpoint
+```
+DELETE /api/users/{id}/saga
+```
+
+Ovo je primjer **brisanja redova međuzavisnih tabela** u različitim mikroservisima.
+
+### Stanja
+```
+User:    ACTIVE → DELETION_PENDING → DELETED   (sretni put — finalno)
+User:    ACTIVE → DELETION_PENDING → ACTIVE    (kompenzacija — restore)
+Bookings: PENDING/CONFIRMED/CANCELLATION_PENDING → CANCELLED   (TX2 — brisanje redova)
+```
+
+### Dijagram toka
+
+```
+Klijent              User Service              RabbitMQ              Booking Service
+  │                      │                        │                       │
+  │──DELETE /users/1/saga→│                        │                       │
+  │                       │                        │                       │
+  │             ┌─────────┴──────┐                │                       │
+  │             │  LOCAL TX 1    │                │                       │
+  │             │ User: ACTIVE → │                │                       │
+  │             │ DELETION_PENDING│               │                       │
+  │             └─────────┬──────┘                │                       │
+  │                       │──UserDeletion─────────→│──────────────────────→│
+  │                       │    RequestedEvent       │                       │
+  │◄──202 Accepted────────│                        │        ┌──────────────┴──────────┐
+  │                       │                        │        │      LOCAL TX 2          │
+  │                       │                        │        │ findByUserIdAndStatusIn  │
+  │                       │                        │        │ Bookings(PENDING/CONFIRMED│
+  │                       │                        │        │   /CANCELLATION_PENDING) │
+  │                       │                        │        │ → sve CANCELLED           │
+  │                       │                        │        │ (brisanje redova via      │
+  │                       │                        │        │  status update)           │
+  │                       │                        │        └──────────────┬──────────┘
+  │                       │◄──UserBookings─────────│◄──────────────────────│
+  │                       │    CancelledEvent       │                       │
+  │             ┌─────────┴──────┐                │                       │
+  │             │ DELETION_PENDING│               │                       │
+  │             │ → DELETED       │               │                       │
+  │             │ (FINALNO)       │               │                       │
+  │             └─────────────────┘               │                       │
+  │
+  │  [ AKO CANCEL BOOKINGA PADNE — KOMPENZACIJA ]
+  │                       │◄──UserBookingsCancellation│◄──────────────────│
+  │                       │    FailedEvent            │                   │
+  │             ┌─────────┴──────┐                │                       │
+  │             │ DELETION_PENDING→ ACTIVE         │                       │
+  │             │ (RESTORE — INVERZNA AKCIJA)      │                       │
+  │             └─────────────────┘                │                       │
+```
+
+### Ključne klase
+
+| Servis | Klasa | Uloga |
+|---|---|---|
+| User | `UserDeletionSagaService` | TX1: ACTIVE→DELETION_PENDING, finalizeDelete(), restoreUser() |
+| User | `UserDeletionSagaPublisher` | Šalje UserDeletionRequestedEvent |
+| User | `UserDeletionSagaConsumer` | Prima UserBookingsCancelled/Failed |
+| Booking | `UserDeletionBookingSagaService` | TX2: cancel svih aktivnih bookinga za userId |
+| Booking | `UserDeletionBookingSagaPublisher` | Šalje UserBookingsCancelled/Failed |
+| Booking | `UserDeletionBookingSagaConsumer` | Prima UserDeletionRequestedEvent |
+
+---
+
+## 7. Mapa svih fajlova
+
+### Booking Service
+
+```
+src/main/java/ba/nwt/bookingservice/
+├── config/
+│   └── RabbitMQConfig.java                      ← Exchange + sve 12 queues + bindings
+├── model/
+│   └── Booking.java                             ← DODANO: CANCELLATION_PENDING u BookingStatus
+├── repository/
+│   └── BookingRepository.java                   ← DODANO: findByUserIdAndStatusIn()
+├── saga/
+│   ├── event/
+│   │   ├── BookingCreatedEvent.java             ← Saga 1
+│   │   ├── PaymentCompletedEvent.java           ← Saga 1
+│   │   ├── PaymentFailedEvent.java              ← Saga 1
+│   │   ├── BookingCancellationRequestedEvent.java ← Saga 2
+│   │   ├── RefundCompletedEvent.java            ← Saga 2
+│   │   ├── RefundFailedEvent.java               ← Saga 2
+│   │   ├── RentalCreatedEvent.java              ← Saga 3
+│   │   ├── RentalPaymentCompletedEvent.java     ← Saga 3
+│   │   ├── RentalPaymentFailedEvent.java        ← Saga 3
+│   │   ├── UserDeletionRequestedEvent.java      ← Saga 4
+│   │   ├── UserBookingsCancelledEvent.java      ← Saga 4
+│   │   └── UserBookingsCancellationFailedEvent.java ← Saga 4
+│   ├── BookingSagaPublisher.java                ← Saga 1
+│   ├── BookingSagaConsumer.java                 ← Saga 1
+│   ├── BookingCancellationSagaPublisher.java    ← Saga 2
+│   ├── BookingCancellationSagaConsumer.java     ← Saga 2
+│   ├── RentalSagaPublisher.java                 ← Saga 3
+│   ├── RentalSagaConsumer.java                  ← Saga 3
+│   ├── UserDeletionBookingSagaPublisher.java    ← Saga 4
+│   └── UserDeletionBookingSagaConsumer.java     ← Saga 4
+├── service/
+│   ├── BookingSagaService.java                  ← Saga 1
+│   ├── BookingCancellationSagaService.java      ← Saga 2
+│   ├── RentalSagaService.java                   ← Saga 3
+│   └── UserDeletionBookingSagaService.java      ← Saga 4
+└── controller/
+    ├── BookingSagaController.java               ← Saga 1: POST /api/bookings/saga
+    ├── BookingCancellationSagaController.java   ← Saga 2: POST /api/bookings/{id}/cancel
+    └── RentalSagaController.java                ← Saga 3: POST /api/rentals/saga
+```
+
+### Payment Service
+
+```
+src/main/java/ba/nwt/paymentservice/
+├── config/
+│   └── RabbitMQConfig.java                      ← Exchange + queues za Sage 1, 2, 3
+├── saga/
+│   ├── event/
+│   │   ├── BookingCreatedEvent.java             ← Saga 1
+│   │   ├── PaymentCompletedEvent.java           ← Saga 1
+│   │   ├── PaymentFailedEvent.java              ← Saga 1
+│   │   ├── BookingCancellationRequestedEvent.java ← Saga 2
+│   │   ├── RefundCompletedEvent.java            ← Saga 2
+│   │   ├── RefundFailedEvent.java               ← Saga 2
+│   │   ├── RentalCreatedEvent.java              ← Saga 3
+│   │   ├── RentalPaymentCompletedEvent.java     ← Saga 3
+│   │   └── RentalPaymentFailedEvent.java        ← Saga 3
+│   ├── PaymentSagaPublisher.java                ← Saga 1
+│   ├── PaymentSagaConsumer.java                 ← Saga 1
+│   ├── RefundSagaPublisher.java                 ← Saga 2
+│   ├── RefundSagaConsumer.java                  ← Saga 2
+│   ├── RentalPaymentSagaPublisher.java          ← Saga 3
+│   └── RentalPaymentSagaConsumer.java           ← Saga 3
+└── service/
+    ├── PaymentSagaService.java                  ← Saga 1
+    ├── RefundSagaService.java                   ← Saga 2
+    └── RentalPaymentSagaService.java            ← Saga 3
+```
+
+### User Service
+
+```
+src/main/java/ba/nwt/userservice/
+├── config/
+│   └── RabbitMQConfig.java                      ← NOVO: Exchange + queues za Sagu 4
+├── model/
+│   └── User.java                                ← DODANO: UserStatus enum + status field
+├── saga/
+│   ├── event/
+│   │   ├── UserDeletionRequestedEvent.java      ← Saga 4
+│   │   ├── UserBookingsCancelledEvent.java      ← Saga 4
+│   │   └── UserBookingsCancellationFailedEvent.java ← Saga 4
+│   ├── UserDeletionSagaPublisher.java           ← Saga 4
+│   └── UserDeletionSagaConsumer.java            ← Saga 4
+├── service/
+│   └── UserDeletionSagaService.java             ← Saga 4
+└── controller/
+    └── UserDeletionSagaController.java          ← Saga 4: DELETE /api/users/{id}/saga
+```
+
+---
+
+## 8. Testovi
+
+### Rezultati
+
+| Servis | Test klasa | Testova | Status |
+|---|---|---|---|
+| Booking | `BookingSagaServiceTest` | 9 | ✅ |
+| Booking | `BookingCancellationSagaServiceTest` | 8 | ✅ |
+| Booking | `RentalSagaServiceTest` | 8 | ✅ |
+| Booking | `UserDeletionBookingSagaServiceTest` | 4 | ✅ |
+| Payment | `PaymentSagaServiceTest` | 5 | ✅ |
+| Payment | `RefundSagaServiceTest` | 5 | ✅ |
+| Payment | `RentalPaymentSagaServiceTest` | 5 | ✅ |
+| User | `UserDeletionSagaServiceTest` | 8 | ✅ |
+| **UKUPNO** | **8 test klasa** | **52** | **✅ 0 grešaka** |
+
+### Konvencija testiranja
+
+Sve test klase koriste `@ExtendWith(MockitoExtension.class)` — čiste unit testove bez Spring konteksta. Svaki servisni metod pokriven je:
+- **Sretnim putem** (happy path)
+- **Kompenzacijskim putem** (simulate failure)
+- **Idempotentnim ponašanjem** (duplikati se ignorišu)
+- **Resource not found** scenarijima
+
+### Pokretanje testova
+
+```bash
+# Booking Service
+cd "Booking Service" && ./mvnw test -Dspring.profiles.active=test
+
+# Payment Service
+cd "Payment Service" && ./mvnw test -Dspring.profiles.active=test
+
+# User Service
+cd "User Service" && ./mvnw test -Dspring.profiles.active=test
+```
+
+---
+
+## 9. Live testiranje
+
+### Preduvjeti
+
+```bash
+# Pokrenuti RabbitMQ + MySQL
+docker compose up -d
+
+# Buildati i pokrenuti servise (svaki u zasebnom terminalu)
+# Booking Service: port 8083
+# Payment Service: port 8084
+# User Service:    port 8081
+```
+
+---
+
+### Saga 1 — Kreiranje rezervacije
+
+```bash
+# Sretni put → booking CONFIRMED + payment PAID
+curl -X POST http://localhost:8083/api/bookings/saga \
+  -H "Content-Type: application/json" \
+  -d '{"userId":1,"facilityId":1,"startTime":"2026-08-01T10:00:00","endTime":"2026-08-01T12:00:00","totalPrice":150.00}'
+
+# Kompenzacija → booking CANCELLED + payment FAILED
+curl -X POST "http://localhost:8083/api/bookings/saga?simulateFailure=true" \
+  -H "Content-Type: application/json" \
+  -d '{"userId":1,"facilityId":1,"startTime":"2026-08-02T10:00:00","endTime":"2026-08-02T12:00:00","totalPrice":150.00}'
+```
+
+**Provjera:**
+```bash
+curl http://localhost:8083/api/bookings/1   # status: "CONFIRMED"
+curl http://localhost:8084/api/payments/booking/1   # status: "PAID"
+```
+
+---
+
+### Saga 2 — Otkazivanje rezervacije
+
+```bash
+# Potrebno: booking mora biti CONFIRMED (prethodno kreiran i potvrđen sagom 1)
+# Sretni put → booking CANCELLED + payment REFUNDED
+curl -X POST http://localhost:8083/api/bookings/1/cancel
+
+# Kompenzacija → booking ostaje CONFIRMED (refund propao)
+curl -X POST "http://localhost:8083/api/bookings/2/cancel?simulateFailure=true"
+```
+
+**Provjera:**
+```bash
+curl http://localhost:8083/api/bookings/1   # status: "CANCELLED"
+curl http://localhost:8084/api/payments/booking/1   # status: "REFUNDED"
+
+curl http://localhost:8083/api/bookings/2   # status: "CONFIRMED" (restore!)
+```
+
+---
+
+### Saga 3 — Najam opreme
+
+```bash
+# Sretni put → rental RESERVED + payment PAID
+curl -X POST http://localhost:8083/api/rentals/saga \
+  -H "Content-Type: application/json" \
+  -d '{"userId":1,"equipmentId":1,"startDate":"2026-08-01","endDate":"2026-08-03","quantity":1,"totalPrice":50.00}'
+
+# Kompenzacija → rental CANCELLED + payment FAILED
+curl -X POST "http://localhost:8083/api/rentals/saga?simulateFailure=true" \
+  -H "Content-Type: application/json" \
+  -d '{"userId":1,"equipmentId":1,"startDate":"2026-08-05","endDate":"2026-08-07","quantity":1,"totalPrice":50.00}'
+```
+
+**Provjera:**
+```bash
+# Sretni put
+curl http://localhost:8083/api/rentals/1   # status: "RESERVED"
+curl http://localhost:8084/api/payments?rentalId=1   # status: "PAID"
+
+# Kompenzacija
+curl http://localhost:8083/api/rentals/2   # status: "CANCELLED"
+```
+
+---
+
+### Saga 4 — Brisanje korisnika
+
+```bash
+# Brisanje korisnika id=2 (koji ima aktivne bookinge)
+# → user DELETED + svi bookingovi CANCELLED
+curl -X DELETE http://localhost:8081/api/users/2/saga
+
+# Provjera
+curl http://localhost:8081/api/users/2   # status: "DELETED"
+curl "http://localhost:8083/api/bookings?userId=2"   # svi status: "CANCELLED"
+```
+
+---
+
+### Provjera u RabbitMQ Management UI
+
+```
+http://localhost:15672  (guest / guest)
+→ Queues → provjeri da je Ready: 0 za sve queues
+→ Overview → ukupan throughput poruka
+```
+
+---
+
+### Praćenje logova (identifikacija po sagaId)
+
+```bash
+# Grep po sagaId u logovima sva 3 servisa
+grep "\[SAGA-CANCEL\]\[abc-123\]" booking-service.log
+grep "\[SAGA-CANCEL\]\[abc-123\]" payment-service.log
+
+# Ili pratiti sve saga logove u realnom vremenu
+tail -f /tmp/booking-service.log | grep "\[SAGA"
+tail -f /tmp/payment-service.log | grep "\[SAGA"
+tail -f /tmp/user-service.log | grep "\[SAGA"
+```
+
+---
+
+## 10. Dijagrami
+
+### Kompletni topologijski pregled svih saga
+
+```
+                      ╔══════════════════════════════════════════╗
+                      ║     sportcenter.saga.exchange            ║
+                      ║         (Topic Exchange)                  ║
+                      ╚══════════════════════════════════════════╝
+                                         │
+        ┌──────────────────┬─────────────┼─────────────┬──────────────────┐
+        │                  │             │             │                  │
+   SAGA 1               SAGA 2       SAGA 3        SAGA 4           (ostalo)
+        │                  │             │             │
+   booking.saga.    booking.saga.   rental.saga.  user.saga.
+   created          cancellation    created       deletion
+        │                  │             │             │
+        ▼                  ▼             ▼             ▼
+   [booking.         [booking.       [rental.      [user.
+   created.q]        cancellation.q] created.q]   deletion.q]
+        │                  │             │             │
+   Payment Svc        Payment Svc   Payment Svc  Booking Svc
+   processes          refunds       processes     cancels user's
+   payment            payment       rental pay.   bookings
+        │                  │             │             │
+   payment.saga.    refund.saga.    rental.pay.   user.saga.
+   completed/failed  completed/f.   compl/failed  bookings.
+                                                  cancelled/f.
+        │                  │             │             │
+        ▼                  ▼             ▼             ▼
+   Booking Svc        Booking Svc   Booking Svc   User Svc
+   confirms or        finalizes     confirms or   finalizes
+   cancels booking    or restores   cancels rental DELETED or
+                      booking                     restores ACTIVE
+```
+
+### Stanja svih modela
+
+```
+User.UserStatus:
+  ACTIVE ──[initiate saga]──→ DELETION_PENDING
+  DELETION_PENDING ──[bookings cancelled]──→ DELETED         (FINALNO)
+  DELETION_PENDING ──[bookings failed]──→ ACTIVE             (KOMPENZACIJA)
+
+Booking.BookingStatus:
+  PENDING ──[payment ok]──→ CONFIRMED                        (FINALNO saga 1)
+  PENDING ──[payment fail]──→ CANCELLED                      (KOMPENZACIJA saga 1)
+  CONFIRMED ──[cancel requested]──→ CANCELLATION_PENDING
+  CANCELLATION_PENDING ──[refund ok]──→ CANCELLED            (FINALNO saga 2)
+  CANCELLATION_PENDING ──[refund fail]──→ CONFIRMED          (KOMPENZACIJA saga 2)
+  PENDING/CONFIRMED ──[user deleted]──→ CANCELLED            (TX2 saga 4)
+
+EquipmentRental.RentalStatus:
+  RESERVED ──[payment ok]──→ RESERVED (ostaje)              (FINALNO saga 3)
+  RESERVED ──[payment fail]──→ CANCELLED                    (KOMPENZACIJA saga 3)
+
+Payment.PaymentStatus:
+  PENDING ──[processing ok]──→ PAID                         (FINALNO saga 1 & 3)
+  PENDING ──[processing fail]──→ FAILED                     (greška saga 1 & 3)
+  PAID ──[refund ok]──→ REFUNDED                            (FINALNO saga 2)
+```
+
+---
+
+## Sažetak ispunjenih zahtjeva
+
+| Zahtjev zadatka | Saga 1 | Saga 2 | Saga 3 | Saga 4 |
+|---|---|---|---|---|
+| Asinkrona komunikacija RabbitMQ | ✅ | ✅ | ✅ | ✅ |
+| Event-based / Choreography | ✅ | ✅ | ✅ | ✅ |
+| ≥2 DB upisa u različitim servisima | ✅ | ✅ | ✅ | ✅ |
+| Lokalne transakcije (@Transactional) | ✅ | ✅ | ✅ | ✅ |
+| Međuzavisnost TX1 ↔ TX2 | ✅ | ✅ | ✅ | ✅ |
+| Kompenzacijska (inverzna) akcija | Booking→CANCELLED | Booking→CONFIRMED | Rental→CANCELLED | User→ACTIVE |
+| Finalno označavanje | Booking→CONFIRMED | Booking→CANCELLED | Rental→RESERVED | User→DELETED |
+| Dijagram komunikacije | ✅ | ✅ | ✅ | ✅ |

--- a/Payment Service/src/main/java/ba/nwt/paymentservice/config/RabbitMQConfig.java
+++ b/Payment Service/src/main/java/ba/nwt/paymentservice/config/RabbitMQConfig.java
@@ -11,65 +11,60 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class RabbitMQConfig {
 
-    // ── Exchange ──────────────────────────────────────────────────────────────
     public static final String SAGA_EXCHANGE = "sportcenter.saga.exchange";
 
-    // ── Queue names ───────────────────────────────────────────────────────────
+    // ── Saga 1: Booking Creation ───────────────────────────────────────────────
     public static final String BOOKING_CREATED_QUEUE   = "sportcenter.booking.created.queue";
     public static final String PAYMENT_COMPLETED_QUEUE = "sportcenter.payment.completed.queue";
     public static final String PAYMENT_FAILED_QUEUE    = "sportcenter.payment.failed.queue";
 
-    // ── Routing keys ──────────────────────────────────────────────────────────
     public static final String BOOKING_CREATED_KEY   = "booking.saga.created";
     public static final String PAYMENT_COMPLETED_KEY = "payment.saga.completed";
     public static final String PAYMENT_FAILED_KEY    = "payment.saga.failed";
+
+    // ── Saga 2: Booking Cancellation + Refund ─────────────────────────────────
+    public static final String BOOKING_CANCELLATION_QUEUE = "sportcenter.booking.cancellation.queue";
+    public static final String REFUND_COMPLETED_QUEUE     = "sportcenter.refund.completed.queue";
+    public static final String REFUND_FAILED_QUEUE        = "sportcenter.refund.failed.queue";
+
+    public static final String BOOKING_CANCELLATION_KEY = "booking.saga.cancellation";
+    public static final String REFUND_COMPLETED_KEY     = "refund.saga.completed";
+    public static final String REFUND_FAILED_KEY        = "refund.saga.failed";
+
+    // ── Saga 3: Rental + Payment ──────────────────────────────────────────────
+    public static final String RENTAL_CREATED_QUEUE           = "sportcenter.rental.created.queue";
+    public static final String RENTAL_PAYMENT_COMPLETED_QUEUE = "sportcenter.rental.payment.completed.queue";
+    public static final String RENTAL_PAYMENT_FAILED_QUEUE    = "sportcenter.rental.payment.failed.queue";
+
+    public static final String RENTAL_CREATED_KEY           = "rental.saga.created";
+    public static final String RENTAL_PAYMENT_COMPLETED_KEY = "rental.payment.saga.completed";
+    public static final String RENTAL_PAYMENT_FAILED_KEY    = "rental.payment.saga.failed";
 
     @Bean
     public TopicExchange sagaExchange() {
         return ExchangeBuilder.topicExchange(SAGA_EXCHANGE).durable(true).build();
     }
 
-    // ── Queues declared by Payment Service (the one it consumes) ─────────────
-    @Bean
-    public Queue bookingCreatedQueue() {
-        return QueueBuilder.durable(BOOKING_CREATED_QUEUE).build();
-    }
+    @Bean public Queue bookingCreatedQueue()           { return QueueBuilder.durable(BOOKING_CREATED_QUEUE).build(); }
+    @Bean public Queue paymentCompletedQueue()         { return QueueBuilder.durable(PAYMENT_COMPLETED_QUEUE).build(); }
+    @Bean public Queue paymentFailedQueue()            { return QueueBuilder.durable(PAYMENT_FAILED_QUEUE).build(); }
+    @Bean public Queue bookingCancellationQueue()      { return QueueBuilder.durable(BOOKING_CANCELLATION_QUEUE).build(); }
+    @Bean public Queue refundCompletedQueue()          { return QueueBuilder.durable(REFUND_COMPLETED_QUEUE).build(); }
+    @Bean public Queue refundFailedQueue()             { return QueueBuilder.durable(REFUND_FAILED_QUEUE).build(); }
+    @Bean public Queue rentalCreatedQueue()            { return QueueBuilder.durable(RENTAL_CREATED_QUEUE).build(); }
+    @Bean public Queue rentalPaymentCompletedQueue()   { return QueueBuilder.durable(RENTAL_PAYMENT_COMPLETED_QUEUE).build(); }
+    @Bean public Queue rentalPaymentFailedQueue()      { return QueueBuilder.durable(RENTAL_PAYMENT_FAILED_QUEUE).build(); }
 
-    // Also declare queues that Booking Service consumes to ensure they exist.
-    @Bean
-    public Queue paymentCompletedQueue() {
-        return QueueBuilder.durable(PAYMENT_COMPLETED_QUEUE).build();
-    }
+    @Bean public Binding bookingCreatedBinding()         { return BindingBuilder.bind(bookingCreatedQueue()).to(sagaExchange()).with(BOOKING_CREATED_KEY); }
+    @Bean public Binding paymentCompletedBinding()       { return BindingBuilder.bind(paymentCompletedQueue()).to(sagaExchange()).with(PAYMENT_COMPLETED_KEY); }
+    @Bean public Binding paymentFailedBinding()          { return BindingBuilder.bind(paymentFailedQueue()).to(sagaExchange()).with(PAYMENT_FAILED_KEY); }
+    @Bean public Binding bookingCancellationBinding()    { return BindingBuilder.bind(bookingCancellationQueue()).to(sagaExchange()).with(BOOKING_CANCELLATION_KEY); }
+    @Bean public Binding refundCompletedBinding()        { return BindingBuilder.bind(refundCompletedQueue()).to(sagaExchange()).with(REFUND_COMPLETED_KEY); }
+    @Bean public Binding refundFailedBinding()           { return BindingBuilder.bind(refundFailedQueue()).to(sagaExchange()).with(REFUND_FAILED_KEY); }
+    @Bean public Binding rentalCreatedBinding()          { return BindingBuilder.bind(rentalCreatedQueue()).to(sagaExchange()).with(RENTAL_CREATED_KEY); }
+    @Bean public Binding rentalPaymentCompletedBinding() { return BindingBuilder.bind(rentalPaymentCompletedQueue()).to(sagaExchange()).with(RENTAL_PAYMENT_COMPLETED_KEY); }
+    @Bean public Binding rentalPaymentFailedBinding()    { return BindingBuilder.bind(rentalPaymentFailedQueue()).to(sagaExchange()).with(RENTAL_PAYMENT_FAILED_KEY); }
 
-    @Bean
-    public Queue paymentFailedQueue() {
-        return QueueBuilder.durable(PAYMENT_FAILED_QUEUE).build();
-    }
-
-    // ── Bindings ──────────────────────────────────────────────────────────────
-    @Bean
-    public Binding bookingCreatedBinding() {
-        return BindingBuilder.bind(bookingCreatedQueue())
-                .to(sagaExchange()).with(BOOKING_CREATED_KEY);
-    }
-
-    @Bean
-    public Binding paymentCompletedBinding() {
-        return BindingBuilder.bind(paymentCompletedQueue())
-                .to(sagaExchange()).with(PAYMENT_COMPLETED_KEY);
-    }
-
-    @Bean
-    public Binding paymentFailedBinding() {
-        return BindingBuilder.bind(paymentFailedQueue())
-                .to(sagaExchange()).with(PAYMENT_FAILED_KEY);
-    }
-
-    // ── JSON message converter ─────────────────────────────────────────────────
-    // Inject Spring Boot's ObjectMapper (has JavaTimeModule → LocalDateTime works).
-    // INFERRED type precedence: use @RabbitListener method's parameter type for
-    // deserialization instead of the __TypeId__ header, which would contain the
-    // sender's package name (not present in this service's classpath).
     @Bean
     public MessageConverter jsonMessageConverter(ObjectMapper objectMapper) {
         Jackson2JsonMessageConverter converter = new Jackson2JsonMessageConverter(objectMapper);

--- a/Payment Service/src/main/java/ba/nwt/paymentservice/saga/RefundSagaConsumer.java
+++ b/Payment Service/src/main/java/ba/nwt/paymentservice/saga/RefundSagaConsumer.java
@@ -1,0 +1,24 @@
+package ba.nwt.paymentservice.saga;
+
+import ba.nwt.paymentservice.config.RabbitMQConfig;
+import ba.nwt.paymentservice.saga.event.BookingCancellationRequestedEvent;
+import ba.nwt.paymentservice.service.RefundSagaService;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RefundSagaConsumer {
+
+    private static final Logger log = LoggerFactory.getLogger(RefundSagaConsumer.class);
+    private final RefundSagaService refundSagaService;
+
+    @RabbitListener(queues = RabbitMQConfig.BOOKING_CANCELLATION_QUEUE)
+    public void onBookingCancellationRequested(BookingCancellationRequestedEvent event) {
+        log.info("[SAGA-CANCEL][{}] Received BookingCancellationRequestedEvent for bookingId={}", event.getSagaId(), event.getBookingId());
+        refundSagaService.processRefund(event);
+    }
+}

--- a/Payment Service/src/main/java/ba/nwt/paymentservice/saga/RefundSagaPublisher.java
+++ b/Payment Service/src/main/java/ba/nwt/paymentservice/saga/RefundSagaPublisher.java
@@ -1,0 +1,28 @@
+package ba.nwt.paymentservice.saga;
+
+import ba.nwt.paymentservice.config.RabbitMQConfig;
+import ba.nwt.paymentservice.saga.event.RefundCompletedEvent;
+import ba.nwt.paymentservice.saga.event.RefundFailedEvent;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RefundSagaPublisher {
+
+    private static final Logger log = LoggerFactory.getLogger(RefundSagaPublisher.class);
+    private final RabbitTemplate rabbitTemplate;
+
+    public void publishRefundCompleted(RefundCompletedEvent event) {
+        log.info("[SAGA-CANCEL][{}] Publishing RefundCompletedEvent for bookingId={}", event.getSagaId(), event.getBookingId());
+        rabbitTemplate.convertAndSend(RabbitMQConfig.SAGA_EXCHANGE, RabbitMQConfig.REFUND_COMPLETED_KEY, event);
+    }
+
+    public void publishRefundFailed(RefundFailedEvent event) {
+        log.warn("[SAGA-CANCEL][{}] Publishing RefundFailedEvent for bookingId={}", event.getSagaId(), event.getBookingId());
+        rabbitTemplate.convertAndSend(RabbitMQConfig.SAGA_EXCHANGE, RabbitMQConfig.REFUND_FAILED_KEY, event);
+    }
+}

--- a/Payment Service/src/main/java/ba/nwt/paymentservice/saga/RentalPaymentSagaConsumer.java
+++ b/Payment Service/src/main/java/ba/nwt/paymentservice/saga/RentalPaymentSagaConsumer.java
@@ -1,0 +1,24 @@
+package ba.nwt.paymentservice.saga;
+
+import ba.nwt.paymentservice.config.RabbitMQConfig;
+import ba.nwt.paymentservice.saga.event.RentalCreatedEvent;
+import ba.nwt.paymentservice.service.RentalPaymentSagaService;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RentalPaymentSagaConsumer {
+
+    private static final Logger log = LoggerFactory.getLogger(RentalPaymentSagaConsumer.class);
+    private final RentalPaymentSagaService service;
+
+    @RabbitListener(queues = RabbitMQConfig.RENTAL_CREATED_QUEUE)
+    public void onRentalCreated(RentalCreatedEvent event) {
+        log.info("[SAGA-RENTAL][{}] Received RentalCreatedEvent for rentalId={}", event.getSagaId(), event.getRentalId());
+        service.processRentalPayment(event);
+    }
+}

--- a/Payment Service/src/main/java/ba/nwt/paymentservice/saga/RentalPaymentSagaPublisher.java
+++ b/Payment Service/src/main/java/ba/nwt/paymentservice/saga/RentalPaymentSagaPublisher.java
@@ -1,0 +1,28 @@
+package ba.nwt.paymentservice.saga;
+
+import ba.nwt.paymentservice.config.RabbitMQConfig;
+import ba.nwt.paymentservice.saga.event.RentalPaymentCompletedEvent;
+import ba.nwt.paymentservice.saga.event.RentalPaymentFailedEvent;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RentalPaymentSagaPublisher {
+
+    private static final Logger log = LoggerFactory.getLogger(RentalPaymentSagaPublisher.class);
+    private final RabbitTemplate rabbitTemplate;
+
+    public void publishCompleted(RentalPaymentCompletedEvent event) {
+        log.info("[SAGA-RENTAL][{}] Publishing RentalPaymentCompletedEvent for rentalId={}", event.getSagaId(), event.getRentalId());
+        rabbitTemplate.convertAndSend(RabbitMQConfig.SAGA_EXCHANGE, RabbitMQConfig.RENTAL_PAYMENT_COMPLETED_KEY, event);
+    }
+
+    public void publishFailed(RentalPaymentFailedEvent event) {
+        log.warn("[SAGA-RENTAL][{}] Publishing RentalPaymentFailedEvent for rentalId={}", event.getSagaId(), event.getRentalId());
+        rabbitTemplate.convertAndSend(RabbitMQConfig.SAGA_EXCHANGE, RabbitMQConfig.RENTAL_PAYMENT_FAILED_KEY, event);
+    }
+}

--- a/Payment Service/src/main/java/ba/nwt/paymentservice/saga/event/BookingCancellationRequestedEvent.java
+++ b/Payment Service/src/main/java/ba/nwt/paymentservice/saga/event/BookingCancellationRequestedEvent.java
@@ -1,0 +1,15 @@
+package ba.nwt.paymentservice.saga.event;
+
+import lombok.*;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data @NoArgsConstructor @AllArgsConstructor @Builder
+public class BookingCancellationRequestedEvent {
+    private String sagaId;
+    private Long bookingId;
+    private Long userId;
+    private BigDecimal refundAmount;
+    private LocalDateTime timestamp;
+    private boolean simulateFailure;
+}

--- a/Payment Service/src/main/java/ba/nwt/paymentservice/saga/event/RefundCompletedEvent.java
+++ b/Payment Service/src/main/java/ba/nwt/paymentservice/saga/event/RefundCompletedEvent.java
@@ -1,0 +1,14 @@
+package ba.nwt.paymentservice.saga.event;
+
+import lombok.*;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data @NoArgsConstructor @AllArgsConstructor @Builder
+public class RefundCompletedEvent {
+    private String sagaId;
+    private Long bookingId;
+    private Long paymentId;
+    private BigDecimal refundedAmount;
+    private LocalDateTime timestamp;
+}

--- a/Payment Service/src/main/java/ba/nwt/paymentservice/saga/event/RefundFailedEvent.java
+++ b/Payment Service/src/main/java/ba/nwt/paymentservice/saga/event/RefundFailedEvent.java
@@ -1,0 +1,12 @@
+package ba.nwt.paymentservice.saga.event;
+
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Data @NoArgsConstructor @AllArgsConstructor @Builder
+public class RefundFailedEvent {
+    private String sagaId;
+    private Long bookingId;
+    private String reason;
+    private LocalDateTime timestamp;
+}

--- a/Payment Service/src/main/java/ba/nwt/paymentservice/saga/event/RentalCreatedEvent.java
+++ b/Payment Service/src/main/java/ba/nwt/paymentservice/saga/event/RentalCreatedEvent.java
@@ -1,0 +1,22 @@
+package ba.nwt.paymentservice.saga.event;
+
+import lombok.*;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Data @NoArgsConstructor @AllArgsConstructor @Builder
+public class RentalCreatedEvent {
+    private String sagaId;
+    private Long rentalId;
+    private Long userId;
+    private Long equipmentId;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private Integer quantity;
+    private BigDecimal totalPrice;
+    private BigDecimal depositAmount;
+    private String paymentMethod;
+    private LocalDateTime timestamp;
+    private boolean simulateFailure;
+}

--- a/Payment Service/src/main/java/ba/nwt/paymentservice/saga/event/RentalPaymentCompletedEvent.java
+++ b/Payment Service/src/main/java/ba/nwt/paymentservice/saga/event/RentalPaymentCompletedEvent.java
@@ -1,0 +1,15 @@
+package ba.nwt.paymentservice.saga.event;
+
+import lombok.*;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data @NoArgsConstructor @AllArgsConstructor @Builder
+public class RentalPaymentCompletedEvent {
+    private String sagaId;
+    private Long rentalId;
+    private Long paymentId;
+    private String transactionId;
+    private BigDecimal amount;
+    private LocalDateTime timestamp;
+}

--- a/Payment Service/src/main/java/ba/nwt/paymentservice/saga/event/RentalPaymentFailedEvent.java
+++ b/Payment Service/src/main/java/ba/nwt/paymentservice/saga/event/RentalPaymentFailedEvent.java
@@ -1,0 +1,12 @@
+package ba.nwt.paymentservice.saga.event;
+
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Data @NoArgsConstructor @AllArgsConstructor @Builder
+public class RentalPaymentFailedEvent {
+    private String sagaId;
+    private Long rentalId;
+    private String reason;
+    private LocalDateTime timestamp;
+}

--- a/Payment Service/src/main/java/ba/nwt/paymentservice/service/RefundSagaService.java
+++ b/Payment Service/src/main/java/ba/nwt/paymentservice/service/RefundSagaService.java
@@ -1,0 +1,78 @@
+package ba.nwt.paymentservice.service;
+
+import ba.nwt.paymentservice.model.Payment;
+import ba.nwt.paymentservice.repository.PaymentRepository;
+import ba.nwt.paymentservice.saga.RefundSagaPublisher;
+import ba.nwt.paymentservice.saga.event.BookingCancellationRequestedEvent;
+import ba.nwt.paymentservice.saga.event.RefundCompletedEvent;
+import ba.nwt.paymentservice.saga.event.RefundFailedEvent;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Booking Cancellation Saga — Payment Service side.
+ *
+ * Local TX 2: find the PAID payment for the booking and mark it as REFUNDED.
+ * On success → publish RefundCompletedEvent → Booking finalised as CANCELLED.
+ * On failure → publish RefundFailedEvent   → Booking restored to CONFIRMED (compensating TX).
+ */
+@Service
+@RequiredArgsConstructor
+public class RefundSagaService {
+
+    private static final Logger log = LoggerFactory.getLogger(RefundSagaService.class);
+
+    private final PaymentRepository paymentRepository;
+    private final RefundSagaPublisher publisher;
+
+    @Transactional
+    public void processRefund(BookingCancellationRequestedEvent event) {
+        log.info("[SAGA-CANCEL][{}] Local TX 2 start — processing refund for bookingId={}", event.getSagaId(), event.getBookingId());
+
+        if (event.isSimulateFailure()) {
+            log.warn("[SAGA-CANCEL][{}] Refund FAILED (simulated) for bookingId={}", event.getSagaId(), event.getBookingId());
+            publisher.publishRefundFailed(RefundFailedEvent.builder()
+                    .sagaId(event.getSagaId())
+                    .bookingId(event.getBookingId())
+                    .reason("Simulated refund failure for bookingId=" + event.getBookingId())
+                    .timestamp(LocalDateTime.now())
+                    .build());
+            return;
+        }
+
+        try {
+            List<Payment> payments = paymentRepository.findByBookingId(event.getBookingId());
+            Payment payment = payments.stream()
+                    .filter(p -> p.getStatus() == Payment.PaymentStatus.PAID)
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException(
+                            "No PAID payment found for bookingId=" + event.getBookingId()));
+
+            payment.setStatus(Payment.PaymentStatus.REFUNDED);
+            Payment saved = paymentRepository.save(payment);
+            log.info("[SAGA-CANCEL][{}] Payment id={} REFUNDED — publishing RefundCompletedEvent", event.getSagaId(), saved.getId());
+
+            publisher.publishRefundCompleted(RefundCompletedEvent.builder()
+                    .sagaId(event.getSagaId())
+                    .bookingId(event.getBookingId())
+                    .paymentId(saved.getId())
+                    .refundedAmount(saved.getAmount())
+                    .timestamp(LocalDateTime.now())
+                    .build());
+        } catch (Exception ex) {
+            log.error("[SAGA-CANCEL][{}] Refund processing error: {}", event.getSagaId(), ex.getMessage());
+            publisher.publishRefundFailed(RefundFailedEvent.builder()
+                    .sagaId(event.getSagaId())
+                    .bookingId(event.getBookingId())
+                    .reason(ex.getMessage())
+                    .timestamp(LocalDateTime.now())
+                    .build());
+        }
+    }
+}

--- a/Payment Service/src/main/java/ba/nwt/paymentservice/service/RentalPaymentSagaService.java
+++ b/Payment Service/src/main/java/ba/nwt/paymentservice/service/RentalPaymentSagaService.java
@@ -1,0 +1,92 @@
+package ba.nwt.paymentservice.service;
+
+import ba.nwt.paymentservice.model.Payment;
+import ba.nwt.paymentservice.repository.PaymentRepository;
+import ba.nwt.paymentservice.saga.RentalPaymentSagaPublisher;
+import ba.nwt.paymentservice.saga.event.RentalCreatedEvent;
+import ba.nwt.paymentservice.saga.event.RentalPaymentCompletedEvent;
+import ba.nwt.paymentservice.saga.event.RentalPaymentFailedEvent;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Equipment Rental Saga — Payment Service side.
+ *
+ * Local TX 2: create and process payment for the rental.
+ * On success → publish RentalPaymentCompletedEvent → Rental confirmed.
+ * On failure → publish RentalPaymentFailedEvent   → Rental cancelled (compensating TX).
+ */
+@Service
+@RequiredArgsConstructor
+public class RentalPaymentSagaService {
+
+    private static final Logger log = LoggerFactory.getLogger(RentalPaymentSagaService.class);
+
+    private final PaymentRepository paymentRepository;
+    private final RentalPaymentSagaPublisher publisher;
+
+    @Transactional
+    public void processRentalPayment(RentalCreatedEvent event) {
+        log.info("[SAGA-RENTAL][{}] Local TX 2 start — processing payment for rentalId={}", event.getSagaId(), event.getRentalId());
+
+        Payment.PaymentMethod method;
+        try {
+            method = Payment.PaymentMethod.valueOf(event.getPaymentMethod());
+        } catch (IllegalArgumentException e) {
+            method = Payment.PaymentMethod.CREDIT_CARD;
+        }
+
+        Payment payment = paymentRepository.save(Payment.builder()
+                .rentalId(event.getRentalId())
+                .amount(event.getTotalPrice())
+                .depositAmount(event.getDepositAmount() != null ? event.getDepositAmount() : java.math.BigDecimal.ZERO)
+                .paymentMethod(method)
+                .transactionId("TXN-RENTAL-" + UUID.randomUUID().toString().substring(0, 8).toUpperCase())
+                .status(Payment.PaymentStatus.PENDING)
+                .build());
+
+        if (event.isSimulateFailure()) {
+            payment.setStatus(Payment.PaymentStatus.FAILED);
+            paymentRepository.save(payment);
+            log.warn("[SAGA-RENTAL][{}] Payment FAILED (simulated) for rentalId={}", event.getSagaId(), event.getRentalId());
+            publisher.publishFailed(RentalPaymentFailedEvent.builder()
+                    .sagaId(event.getSagaId())
+                    .rentalId(event.getRentalId())
+                    .reason("Simulated payment failure for rentalId=" + event.getRentalId())
+                    .timestamp(LocalDateTime.now())
+                    .build());
+            return;
+        }
+
+        try {
+            payment.setStatus(Payment.PaymentStatus.PAID);
+            payment.setPaidAt(LocalDateTime.now());
+            Payment saved = paymentRepository.save(payment);
+            log.info("[SAGA-RENTAL][{}] Payment id={} PAID for rentalId={}", event.getSagaId(), saved.getId(), event.getRentalId());
+            publisher.publishCompleted(RentalPaymentCompletedEvent.builder()
+                    .sagaId(event.getSagaId())
+                    .rentalId(event.getRentalId())
+                    .paymentId(saved.getId())
+                    .transactionId(saved.getTransactionId())
+                    .amount(saved.getAmount())
+                    .timestamp(LocalDateTime.now())
+                    .build());
+        } catch (Exception ex) {
+            payment.setStatus(Payment.PaymentStatus.FAILED);
+            paymentRepository.save(payment);
+            log.error("[SAGA-RENTAL][{}] Unexpected error during rental payment: {}", event.getSagaId(), ex.getMessage());
+            publisher.publishFailed(RentalPaymentFailedEvent.builder()
+                    .sagaId(event.getSagaId())
+                    .rentalId(event.getRentalId())
+                    .reason("Internal error: " + ex.getMessage())
+                    .timestamp(LocalDateTime.now())
+                    .build());
+        }
+    }
+}

--- a/Payment Service/src/test/java/ba/nwt/paymentservice/saga/RefundSagaServiceTest.java
+++ b/Payment Service/src/test/java/ba/nwt/paymentservice/saga/RefundSagaServiceTest.java
@@ -1,0 +1,112 @@
+package ba.nwt.paymentservice.saga;
+
+import ba.nwt.paymentservice.model.Payment;
+import ba.nwt.paymentservice.repository.PaymentRepository;
+import ba.nwt.paymentservice.saga.event.BookingCancellationRequestedEvent;
+import ba.nwt.paymentservice.saga.event.RefundCompletedEvent;
+import ba.nwt.paymentservice.saga.event.RefundFailedEvent;
+import ba.nwt.paymentservice.service.RefundSagaService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RefundSagaServiceTest {
+
+    @Mock PaymentRepository paymentRepository;
+    @Mock RefundSagaPublisher publisher;
+    @InjectMocks RefundSagaService service;
+
+    private Payment paidPayment;
+
+    @BeforeEach
+    void setUp() {
+        paidPayment = Payment.builder()
+                .id(99L).bookingId(10L).amount(new BigDecimal("150.00"))
+                .status(Payment.PaymentStatus.PAID).transactionId("TXN-ABC").build();
+    }
+
+    private BookingCancellationRequestedEvent buildEvent(boolean simulateFailure) {
+        return BookingCancellationRequestedEvent.builder()
+                .sagaId("saga-cancel-01").bookingId(10L).userId(1L)
+                .refundAmount(new BigDecimal("150.00"))
+                .simulateFailure(simulateFailure).timestamp(LocalDateTime.now()).build();
+    }
+
+    // ── Happy path ────────────────────────────────────────────────────────────
+
+    @Test
+    void processRefund_happyPath_setsPaymentRefunded_andPublishesCompleted() {
+        when(paymentRepository.findByBookingId(10L)).thenReturn(List.of(paidPayment));
+        when(paymentRepository.save(any())).thenReturn(paidPayment);
+
+        service.processRefund(buildEvent(false));
+
+        ArgumentCaptor<Payment> captor = ArgumentCaptor.forClass(Payment.class);
+        verify(paymentRepository).save(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(Payment.PaymentStatus.REFUNDED);
+
+        verify(publisher).publishRefundCompleted(argThat(e ->
+                e.getSagaId().equals("saga-cancel-01") && e.getBookingId().equals(10L)));
+        verify(publisher, never()).publishRefundFailed(any());
+    }
+
+    // ── Simulate failure (compensating) ──────────────────────────────────────
+
+    @Test
+    void processRefund_withSimulateFailure_publishesRefundFailed() {
+        service.processRefund(buildEvent(true));
+
+        verify(publisher).publishRefundFailed(argThat(e ->
+                e.getBookingId().equals(10L) && e.getReason() != null));
+        verify(publisher, never()).publishRefundCompleted(any());
+        verifyNoInteractions(paymentRepository);
+    }
+
+    // ── No PAID payment ───────────────────────────────────────────────────────
+
+    @Test
+    void processRefund_noPaidPayment_publishesRefundFailed() {
+        paidPayment.setStatus(Payment.PaymentStatus.PENDING);
+        when(paymentRepository.findByBookingId(10L)).thenReturn(List.of(paidPayment));
+
+        service.processRefund(buildEvent(false));
+
+        verify(publisher).publishRefundFailed(argThat(e ->
+                e.getBookingId().equals(10L) && e.getReason().contains("No PAID payment")));
+        verify(publisher, never()).publishRefundCompleted(any());
+    }
+
+    @Test
+    void processRefund_noPaymentAtAll_publishesRefundFailed() {
+        when(paymentRepository.findByBookingId(10L)).thenReturn(List.of());
+
+        service.processRefund(buildEvent(false));
+
+        verify(publisher).publishRefundFailed(any());
+        verify(publisher, never()).publishRefundCompleted(any());
+    }
+
+    // ── Repository exception ──────────────────────────────────────────────────
+
+    @Test
+    void processRefund_onRepositoryException_publishesRefundFailed() {
+        when(paymentRepository.findByBookingId(10L)).thenThrow(new RuntimeException("DB error"));
+
+        service.processRefund(buildEvent(false));
+
+        verify(publisher).publishRefundFailed(argThat(e -> e.getReason().contains("DB error")));
+    }
+}

--- a/Payment Service/src/test/java/ba/nwt/paymentservice/saga/RentalPaymentSagaServiceTest.java
+++ b/Payment Service/src/test/java/ba/nwt/paymentservice/saga/RentalPaymentSagaServiceTest.java
@@ -1,0 +1,127 @@
+package ba.nwt.paymentservice.saga;
+
+import ba.nwt.paymentservice.model.Payment;
+import ba.nwt.paymentservice.repository.PaymentRepository;
+import ba.nwt.paymentservice.saga.event.RentalCreatedEvent;
+import ba.nwt.paymentservice.service.RentalPaymentSagaService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RentalPaymentSagaServiceTest {
+
+    @Mock PaymentRepository paymentRepository;
+    @Mock RentalPaymentSagaPublisher publisher;
+    @InjectMocks RentalPaymentSagaService service;
+
+    private RentalCreatedEvent baseEvent;
+
+    @BeforeEach
+    void setUp() {
+        baseEvent = RentalCreatedEvent.builder()
+                .sagaId("saga-rental-01").rentalId(20L).userId(1L).equipmentId(5L)
+                .startDate(LocalDate.now().plusDays(1)).endDate(LocalDate.now().plusDays(3))
+                .quantity(1).totalPrice(new BigDecimal("50.00"))
+                .depositAmount(BigDecimal.ZERO).paymentMethod("CREDIT_CARD")
+                .simulateFailure(false).timestamp(LocalDateTime.now()).build();
+    }
+
+    // ── Happy path ────────────────────────────────────────────────────────────
+
+    @Test
+    void processRentalPayment_happyPath_savesPendingThenPaid_andPublishesCompleted() {
+        Payment pending = Payment.builder().id(55L).rentalId(20L)
+                .status(Payment.PaymentStatus.PENDING).transactionId("TXN-RENTAL-AAA").build();
+
+        when(paymentRepository.save(any())).thenReturn(pending)
+                .thenReturn(Payment.builder().id(55L).status(Payment.PaymentStatus.PAID)
+                        .transactionId("TXN-RENTAL-AAA").build());
+
+        service.processRentalPayment(baseEvent);
+
+        ArgumentCaptor<Payment> captor = ArgumentCaptor.forClass(Payment.class);
+        verify(paymentRepository, times(2)).save(captor.capture());
+        assertThat(captor.getAllValues().get(0).getStatus()).isEqualTo(Payment.PaymentStatus.PENDING);
+        assertThat(captor.getAllValues().get(1).getStatus()).isEqualTo(Payment.PaymentStatus.PAID);
+
+        verify(publisher).publishCompleted(argThat(e -> e.getRentalId().equals(20L)));
+        verify(publisher, never()).publishFailed(any());
+    }
+
+    @Test
+    void processRentalPayment_transactionIdHasRentalPrefix() {
+        when(paymentRepository.save(any())).thenAnswer(inv -> {
+            Payment p = inv.getArgument(0);
+            p.setId(1L);
+            return p;
+        });
+
+        service.processRentalPayment(baseEvent);
+
+        ArgumentCaptor<Payment> captor = ArgumentCaptor.forClass(Payment.class);
+        verify(paymentRepository, atLeastOnce()).save(captor.capture());
+        assertThat(captor.getAllValues().get(0).getTransactionId()).startsWith("TXN-RENTAL-");
+    }
+
+    // ── Simulate failure (compensating) ──────────────────────────────────────
+
+    @Test
+    void processRentalPayment_withSimulateFailure_savesAsFailed_andPublishesFailed() {
+        baseEvent.setSimulateFailure(true);
+        Payment pending = Payment.builder().id(55L).status(Payment.PaymentStatus.PENDING).build();
+
+        when(paymentRepository.save(any())).thenReturn(pending)
+                .thenReturn(Payment.builder().id(55L).status(Payment.PaymentStatus.FAILED).build());
+
+        service.processRentalPayment(baseEvent);
+
+        ArgumentCaptor<Payment> captor = ArgumentCaptor.forClass(Payment.class);
+        verify(paymentRepository, times(2)).save(captor.capture());
+        assertThat(captor.getAllValues().get(1).getStatus()).isEqualTo(Payment.PaymentStatus.FAILED);
+
+        verify(publisher).publishFailed(argThat(e -> e.getRentalId().equals(20L)));
+        verify(publisher, never()).publishCompleted(any());
+    }
+
+    // ── Exception during processing ───────────────────────────────────────────
+
+    @Test
+    void processRentalPayment_onException_publishesFailed() {
+        Payment pending = Payment.builder().id(55L).status(Payment.PaymentStatus.PENDING).build();
+        when(paymentRepository.save(any()))
+                .thenReturn(pending)
+                .thenThrow(new RuntimeException("DB connection lost"))
+                .thenReturn(Payment.builder().id(55L).status(Payment.PaymentStatus.FAILED).build());
+
+        service.processRentalPayment(baseEvent);
+
+        verify(publisher).publishFailed(argThat(e -> e.getReason().contains("DB connection lost")));
+    }
+
+    // ── PaymentMethod fallback ────────────────────────────────────────────────
+
+    @Test
+    void processRentalPayment_unknownPaymentMethod_defaultsToCreditCard() {
+        baseEvent.setPaymentMethod("CRYPTO");
+        when(paymentRepository.save(any())).thenAnswer(inv -> { Payment p = inv.getArgument(0); p.setId(1L); return p; });
+
+        service.processRentalPayment(baseEvent);
+
+        ArgumentCaptor<Payment> captor = ArgumentCaptor.forClass(Payment.class);
+        verify(paymentRepository, atLeastOnce()).save(captor.capture());
+        assertThat(captor.getAllValues().get(0).getPaymentMethod()).isEqualTo(Payment.PaymentMethod.CREDIT_CARD);
+    }
+}

--- a/User Service/pom.xml
+++ b/User Service/pom.xml
@@ -129,6 +129,15 @@
             <version>0.11.5</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-amqp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.amqp</groupId>
+            <artifactId>spring-rabbit-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/User Service/src/main/java/ba/nwt/userservice/config/RabbitMQConfig.java
+++ b/User Service/src/main/java/ba/nwt/userservice/config/RabbitMQConfig.java
@@ -1,0 +1,44 @@
+package ba.nwt.userservice.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.amqp.core.*;
+import org.springframework.amqp.support.converter.Jackson2JavaTypeMapper;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfig {
+
+    public static final String SAGA_EXCHANGE = "sportcenter.saga.exchange";
+
+    // ── Saga 4: User Deletion ─────────────────────────────────────────────────
+    public static final String USER_DELETION_QUEUE           = "sportcenter.user.deletion.queue";
+    public static final String USER_BOOKINGS_CANCELLED_QUEUE = "sportcenter.user.bookings.cancelled.queue";
+    public static final String USER_BOOKINGS_FAILED_QUEUE    = "sportcenter.user.bookings.failed.queue";
+
+    public static final String USER_DELETION_KEY           = "user.saga.deletion";
+    public static final String USER_BOOKINGS_CANCELLED_KEY = "user.saga.bookings.cancelled";
+    public static final String USER_BOOKINGS_FAILED_KEY    = "user.saga.bookings.failed";
+
+    @Bean
+    public TopicExchange sagaExchange() {
+        return ExchangeBuilder.topicExchange(SAGA_EXCHANGE).durable(true).build();
+    }
+
+    @Bean public Queue userDeletionQueue()             { return QueueBuilder.durable(USER_DELETION_QUEUE).build(); }
+    @Bean public Queue userBookingsCancelledQueue()    { return QueueBuilder.durable(USER_BOOKINGS_CANCELLED_QUEUE).build(); }
+    @Bean public Queue userBookingsFailedQueue()       { return QueueBuilder.durable(USER_BOOKINGS_FAILED_QUEUE).build(); }
+
+    @Bean public Binding userDeletionBinding()           { return BindingBuilder.bind(userDeletionQueue()).to(sagaExchange()).with(USER_DELETION_KEY); }
+    @Bean public Binding userBookingsCancelledBinding()  { return BindingBuilder.bind(userBookingsCancelledQueue()).to(sagaExchange()).with(USER_BOOKINGS_CANCELLED_KEY); }
+    @Bean public Binding userBookingsFailedBinding()     { return BindingBuilder.bind(userBookingsFailedQueue()).to(sagaExchange()).with(USER_BOOKINGS_FAILED_KEY); }
+
+    @Bean
+    public MessageConverter jsonMessageConverter(ObjectMapper objectMapper) {
+        Jackson2JsonMessageConverter converter = new Jackson2JsonMessageConverter(objectMapper);
+        converter.setTypePrecedence(Jackson2JavaTypeMapper.TypePrecedence.INFERRED);
+        return converter;
+    }
+}

--- a/User Service/src/main/java/ba/nwt/userservice/controller/UserDeletionSagaController.java
+++ b/User Service/src/main/java/ba/nwt/userservice/controller/UserDeletionSagaController.java
@@ -1,0 +1,34 @@
+package ba.nwt.userservice.controller;
+
+import ba.nwt.userservice.service.UserDeletionSagaService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * DELETE /api/users/{id}/saga
+ *
+ * Initiates the User Deletion Saga:
+ * 1. User ACTIVE → DELETION_PENDING (local TX 1)
+ * 2. Booking Service cancels all active bookings (local TX 2)
+ *    → Cancel OK   → User DELETED              (final state)
+ *    → Cancel KO   → User restored ACTIVE      (compensating action)
+ */
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+@Tag(name = "User Deletion Saga", description = "Async user deletion with cascade booking cancellation via RabbitMQ")
+public class UserDeletionSagaController {
+
+    private final UserDeletionSagaService service;
+
+    @DeleteMapping("/{id}/saga")
+    @Operation(summary = "Delete user with async cascade booking cancellation (Saga Choreography)")
+    public ResponseEntity<Void> deleteViaSaga(@PathVariable Long id) {
+        service.initiate(id);
+        return ResponseEntity.status(HttpStatus.ACCEPTED).build();
+    }
+}

--- a/User Service/src/main/java/ba/nwt/userservice/model/User.java
+++ b/User Service/src/main/java/ba/nwt/userservice/model/User.java
@@ -31,13 +31,21 @@ public class User {
     @Column(length = 20)
     private String phone;
 
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(20) DEFAULT 'ACTIVE'")
+    private UserStatus status = UserStatus.ACTIVE;
+
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
 
-    // ── Enum ──
+    // ── Enums ──
     public enum Role {
         USER, OWNER, ADMIN
+    }
+
+    public enum UserStatus {
+        ACTIVE, DELETION_PENDING, DELETED
     }
 }
 

--- a/User Service/src/main/java/ba/nwt/userservice/saga/UserDeletionSagaConsumer.java
+++ b/User Service/src/main/java/ba/nwt/userservice/saga/UserDeletionSagaConsumer.java
@@ -1,0 +1,31 @@
+package ba.nwt.userservice.saga;
+
+import ba.nwt.userservice.config.RabbitMQConfig;
+import ba.nwt.userservice.saga.event.UserBookingsCancelledEvent;
+import ba.nwt.userservice.saga.event.UserBookingsCancellationFailedEvent;
+import ba.nwt.userservice.service.UserDeletionSagaService;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserDeletionSagaConsumer {
+
+    private static final Logger log = LoggerFactory.getLogger(UserDeletionSagaConsumer.class);
+    private final UserDeletionSagaService service;
+
+    @RabbitListener(queues = RabbitMQConfig.USER_BOOKINGS_CANCELLED_QUEUE)
+    public void onUserBookingsCancelled(UserBookingsCancelledEvent event) {
+        log.info("[SAGA-USER][{}] Received UserBookingsCancelledEvent for userId={}", event.getSagaId(), event.getUserId());
+        service.finalizeDelete(event);
+    }
+
+    @RabbitListener(queues = RabbitMQConfig.USER_BOOKINGS_FAILED_QUEUE)
+    public void onUserBookingsCancellationFailed(UserBookingsCancellationFailedEvent event) {
+        log.warn("[SAGA-USER][{}] Received UserBookingsCancellationFailedEvent for userId={}", event.getSagaId(), event.getUserId());
+        service.restoreUser(event);
+    }
+}

--- a/User Service/src/main/java/ba/nwt/userservice/saga/UserDeletionSagaPublisher.java
+++ b/User Service/src/main/java/ba/nwt/userservice/saga/UserDeletionSagaPublisher.java
@@ -1,0 +1,22 @@
+package ba.nwt.userservice.saga;
+
+import ba.nwt.userservice.config.RabbitMQConfig;
+import ba.nwt.userservice.saga.event.UserDeletionRequestedEvent;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserDeletionSagaPublisher {
+
+    private static final Logger log = LoggerFactory.getLogger(UserDeletionSagaPublisher.class);
+    private final RabbitTemplate rabbitTemplate;
+
+    public void publishUserDeletionRequested(UserDeletionRequestedEvent event) {
+        log.info("[SAGA-USER][{}] Publishing UserDeletionRequestedEvent for userId={}", event.getSagaId(), event.getUserId());
+        rabbitTemplate.convertAndSend(RabbitMQConfig.SAGA_EXCHANGE, RabbitMQConfig.USER_DELETION_KEY, event);
+    }
+}

--- a/User Service/src/main/java/ba/nwt/userservice/saga/event/UserBookingsCancellationFailedEvent.java
+++ b/User Service/src/main/java/ba/nwt/userservice/saga/event/UserBookingsCancellationFailedEvent.java
@@ -1,0 +1,17 @@
+package ba.nwt.userservice.saga.event;
+
+import lombok.*;
+import java.time.LocalDateTime;
+
+/**
+ * Published by Booking Service when cancellation of user's bookings fails.
+ * Consumed by User Service to execute the compensating action:
+ * restore user from DELETION_PENDING back to ACTIVE.
+ */
+@Data @NoArgsConstructor @AllArgsConstructor @Builder
+public class UserBookingsCancellationFailedEvent {
+    private String sagaId;
+    private Long userId;
+    private String reason;
+    private LocalDateTime timestamp;
+}

--- a/User Service/src/main/java/ba/nwt/userservice/saga/event/UserBookingsCancelledEvent.java
+++ b/User Service/src/main/java/ba/nwt/userservice/saga/event/UserBookingsCancelledEvent.java
@@ -1,0 +1,16 @@
+package ba.nwt.userservice.saga.event;
+
+import lombok.*;
+import java.time.LocalDateTime;
+
+/**
+ * Published by Booking Service when all active bookings for the user are cancelled.
+ * Consumed by User Service to finalize user deletion (DELETED — final state).
+ */
+@Data @NoArgsConstructor @AllArgsConstructor @Builder
+public class UserBookingsCancelledEvent {
+    private String sagaId;
+    private Long userId;
+    private int cancelledCount;
+    private LocalDateTime timestamp;
+}

--- a/User Service/src/main/java/ba/nwt/userservice/saga/event/UserDeletionRequestedEvent.java
+++ b/User Service/src/main/java/ba/nwt/userservice/saga/event/UserDeletionRequestedEvent.java
@@ -1,0 +1,16 @@
+package ba.nwt.userservice.saga.event;
+
+import lombok.*;
+import java.time.LocalDateTime;
+
+/**
+ * Published by User Service when a user deletion is initiated.
+ * Consumed by Booking Service to cancel all active bookings for that user (local TX 2).
+ */
+@Data @NoArgsConstructor @AllArgsConstructor @Builder
+public class UserDeletionRequestedEvent {
+    private String sagaId;
+    private Long userId;
+    private String username;
+    private LocalDateTime timestamp;
+}

--- a/User Service/src/main/java/ba/nwt/userservice/service/UserDeletionSagaService.java
+++ b/User Service/src/main/java/ba/nwt/userservice/service/UserDeletionSagaService.java
@@ -1,0 +1,92 @@
+package ba.nwt.userservice.service;
+
+import ba.nwt.userservice.exception.ResourceNotFoundException;
+import ba.nwt.userservice.model.User;
+import ba.nwt.userservice.repository.UserRepository;
+import ba.nwt.userservice.saga.UserDeletionSagaPublisher;
+import ba.nwt.userservice.saga.event.UserBookingsCancelledEvent;
+import ba.nwt.userservice.saga.event.UserBookingsCancellationFailedEvent;
+import ba.nwt.userservice.saga.event.UserDeletionRequestedEvent;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * User Deletion Saga — User Service side.
+ *
+ * Steps:
+ *  1. initiate()      — User ACTIVE → DELETION_PENDING  [local TX 1]
+ *                       → publish UserDeletionRequestedEvent
+ *  2. finalizeDelete()— User DELETION_PENDING → DELETED  [final state]
+ *  3. restoreUser()   — User DELETION_PENDING → ACTIVE   [compensating / inverse of TX1]
+ */
+@Service
+@RequiredArgsConstructor
+public class UserDeletionSagaService {
+
+    private static final Logger log = LoggerFactory.getLogger(UserDeletionSagaService.class);
+
+    private final UserRepository userRepository;
+    private final UserDeletionSagaPublisher publisher;
+
+    /** Local TX 1: mark user as DELETION_PENDING and trigger cascade booking cancellation. */
+    @Transactional
+    public void initiate(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found id=" + userId));
+
+        if (user.getStatus() != User.UserStatus.ACTIVE) {
+            throw new IllegalStateException("Only ACTIVE users can be deleted via saga (current: " + user.getStatus() + ")");
+        }
+
+        String sagaId = UUID.randomUUID().toString();
+        user.setStatus(User.UserStatus.DELETION_PENDING);
+        userRepository.save(user);
+        log.info("[SAGA-USER][{}] Local TX 1 — User id={} → DELETION_PENDING", sagaId, userId);
+
+        publisher.publishUserDeletionRequested(UserDeletionRequestedEvent.builder()
+                .sagaId(sagaId)
+                .userId(userId)
+                .username(user.getUsername())
+                .timestamp(LocalDateTime.now())
+                .build());
+    }
+
+    /** Triggered by UserBookingsCancelledEvent — user is permanently DELETED (final state). */
+    @Transactional
+    public void finalizeDelete(UserBookingsCancelledEvent event) {
+        User user = userRepository.findById(event.getUserId())
+                .orElseThrow(() -> new ResourceNotFoundException("User not found id=" + event.getUserId()));
+
+        if (user.getStatus() != User.UserStatus.DELETION_PENDING) {
+            log.warn("[SAGA-USER][{}] finalizeDelete skipped — user {} already in {}", event.getSagaId(), event.getUserId(), user.getStatus());
+            return;
+        }
+        user.setStatus(User.UserStatus.DELETED);
+        userRepository.save(user);
+        log.info("[SAGA-USER][{}] User id={} DELETED — saga COMPLETE ({} bookings cancelled)", event.getSagaId(), event.getUserId(), event.getCancelledCount());
+    }
+
+    /**
+     * Triggered by UserBookingsCancellationFailedEvent — compensating action.
+     * Restores user from DELETION_PENDING back to ACTIVE.
+     */
+    @Transactional
+    public void restoreUser(UserBookingsCancellationFailedEvent event) {
+        User user = userRepository.findById(event.getUserId())
+                .orElseThrow(() -> new ResourceNotFoundException("User not found id=" + event.getUserId()));
+
+        if (user.getStatus() != User.UserStatus.DELETION_PENDING) {
+            log.warn("[SAGA-USER][{}] restoreUser skipped — user {} already in {}", event.getSagaId(), event.getUserId(), user.getStatus());
+            return;
+        }
+        user.setStatus(User.UserStatus.ACTIVE);
+        userRepository.save(user);
+        log.warn("[SAGA-USER][{}] User id={} RESTORED to ACTIVE (compensating TX) — reason: {}", event.getSagaId(), event.getUserId(), event.getReason());
+    }
+}

--- a/User Service/src/main/resources/application.properties
+++ b/User Service/src/main/resources/application.properties
@@ -34,3 +34,10 @@ springdoc.swagger-ui.path=/swagger-ui.html
 jwt.secret=${JWT_SECRET:SportsCenterSystemSecretKeyForJWTTokenDevelopmentOnly2026}
 jwt.expiration=${JWT_EXPIRATION:86400}
 jwt.refresh.expiration=${JWT_REFRESH_EXPIRATION:604800}
+
+# ── RabbitMQ ──────────────────────────────────────────────────────────────────
+spring.rabbitmq.host=${RABBITMQ_HOST:localhost}
+spring.rabbitmq.port=${RABBITMQ_PORT:5672}
+spring.rabbitmq.username=${RABBITMQ_USER:guest}
+spring.rabbitmq.password=${RABBITMQ_PASS:guest}
+spring.rabbitmq.virtual-host=/

--- a/User Service/src/test/java/ba/nwt/userservice/UserServiceApplicationTests.java
+++ b/User Service/src/test/java/ba/nwt/userservice/UserServiceApplicationTests.java
@@ -8,6 +8,9 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 class UserServiceApplicationTests {
 
+    @org.springframework.boot.test.mock.mockito.MockBean
+    private org.springframework.amqp.rabbit.core.RabbitTemplate rabbitTemplate;
+
     @Test
     void contextLoads() {
     }

--- a/User Service/src/test/java/ba/nwt/userservice/saga/UserDeletionSagaServiceTest.java
+++ b/User Service/src/test/java/ba/nwt/userservice/saga/UserDeletionSagaServiceTest.java
@@ -1,0 +1,129 @@
+package ba.nwt.userservice.saga;
+
+import ba.nwt.userservice.exception.ResourceNotFoundException;
+import ba.nwt.userservice.model.User;
+import ba.nwt.userservice.repository.UserRepository;
+import ba.nwt.userservice.saga.event.UserBookingsCancelledEvent;
+import ba.nwt.userservice.saga.event.UserBookingsCancellationFailedEvent;
+import ba.nwt.userservice.service.UserDeletionSagaService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserDeletionSagaServiceTest {
+
+    @Mock UserRepository userRepository;
+    @Mock UserDeletionSagaPublisher publisher;
+    @InjectMocks UserDeletionSagaService service;
+
+    private User activeUser;
+
+    @BeforeEach
+    void setUp() {
+        activeUser = User.builder()
+                .id(1L).username("test_user").email("test@example.com")
+                .passwordHash("hash").role(User.Role.USER)
+                .status(User.UserStatus.ACTIVE).build();
+    }
+
+    // ── initiate() ────────────────────────────────────────────────────────────
+
+    @Test
+    void initiate_setsUserToDeletionPending_andPublishesEvent() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(activeUser));
+        when(userRepository.save(any())).thenReturn(activeUser);
+
+        service.initiate(1L);
+
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(User.UserStatus.DELETION_PENDING);
+
+        verify(publisher).publishUserDeletionRequested(argThat(e ->
+                e.getUserId().equals(1L) && "test_user".equals(e.getUsername())));
+    }
+
+    @Test
+    void initiate_throwsIllegalState_whenUserNotActive() {
+        activeUser.setStatus(User.UserStatus.DELETION_PENDING);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(activeUser));
+
+        assertThatThrownBy(() -> service.initiate(1L)).isInstanceOf(IllegalStateException.class);
+        verifyNoInteractions(publisher);
+    }
+
+    @Test
+    void initiate_throwsResourceNotFound_whenUserMissing() {
+        when(userRepository.findById(99L)).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> service.initiate(99L)).isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    // ── finalizeDelete() ──────────────────────────────────────────────────────
+
+    @Test
+    void finalizeDelete_setsUserToDeleted_finalState() {
+        activeUser.setStatus(User.UserStatus.DELETION_PENDING);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(activeUser));
+        when(userRepository.save(any())).thenReturn(activeUser);
+
+        service.finalizeDelete(UserBookingsCancelledEvent.builder()
+                .sagaId("s").userId(1L).cancelledCount(3).timestamp(LocalDateTime.now()).build());
+
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(User.UserStatus.DELETED);
+    }
+
+    @Test
+    void finalizeDelete_isIdempotent_whenAlreadyDeleted() {
+        activeUser.setStatus(User.UserStatus.DELETED);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(activeUser));
+
+        service.finalizeDelete(UserBookingsCancelledEvent.builder().sagaId("s").userId(1L).cancelledCount(0).build());
+        verify(userRepository, never()).save(any());
+    }
+
+    // ── restoreUser() (compensating) ──────────────────────────────────────────
+
+    @Test
+    void restoreUser_compensatingAction_setsUserBackToActive() {
+        activeUser.setStatus(User.UserStatus.DELETION_PENDING);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(activeUser));
+        when(userRepository.save(any())).thenReturn(activeUser);
+
+        service.restoreUser(UserBookingsCancellationFailedEvent.builder()
+                .sagaId("s").userId(1L).reason("DB error").timestamp(LocalDateTime.now()).build());
+
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(User.UserStatus.ACTIVE);
+    }
+
+    @Test
+    void restoreUser_isIdempotent_whenAlreadyActive() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(activeUser));
+
+        service.restoreUser(UserBookingsCancellationFailedEvent.builder().sagaId("s").userId(1L).reason("dup").build());
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    void restoreUser_throwsResourceNotFound_whenUserMissing() {
+        when(userRepository.findById(99L)).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> service.restoreUser(
+                UserBookingsCancellationFailedEvent.builder().sagaId("s").userId(99L).reason("x").build()))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+}

--- a/User Service/src/test/resources/application-test.properties
+++ b/User Service/src/test/resources/application-test.properties
@@ -29,5 +29,8 @@ jwt.secret=TestSecretKeyForIntegrationTestsOnlySportsCenterSystem2026
 jwt.expiration=86400
 jwt.refresh.expiration=604800
 
+# ── Disable RabbitMQ in unit/slice tests ──────────────────────────────────────
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration
+
 
 


### PR DESCRIPTION
  Adds three new sagas on top of the existing booking-creation saga, covering all scenarios where microservice data is interdependent. All sagas follow the same event-based choreography pattern with compensating (inverse) transactions.

  New sagas:

  - Booking Cancellation + Refund (POST /api/bookings/{id}/cancel) — marks a confirmed booking as CANCELLATION_PENDING (TX1, Booking Service), triggers a payment refund in Payment Service (TX2). On refund success → booking CANCELLED (final). On
  refund failure → booking restored to CONFIRMED (compensating action).
  - Equipment Rental + Payment (POST /api/rentals/saga) — saves a rental as RESERVED (TX1, Booking Service), creates and charges a payment in Payment Service (TX2). On payment failure → rental CANCELLED (compensating action).
  - User Deletion + Cascade Booking Cancellation (DELETE /api/users/{id}/saga) — marks the user as DELETION_PENDING (TX1, User Service), cancels all active bookings for that user in Booking Service (TX2). On success → user DELETED (final). On
  failure → user restored to ACTIVE (compensating action). This is the canonical example of cascading a delete across microservice boundaries.

  Infrastructure:
  - RabbitMQ now has 12 durable queues across all sagas on a single topic exchange (sportcenter.saga.exchange)
  - User Service wired up with Spring AMQP for the first time
  - User entity: added UserStatus enum (ACTIVE, DELETION_PENDING, DELETED)
  - Booking entity: added CANCELLATION_PENDING status
  - BookingRepository: added findByUserIdAndStatusIn()

  Tests: 52 new unit tests (8 test classes) — happy path, compensating path, idempotency, and error handling for every saga step. Total across all services: 148 tests, 0 failures.